### PR TITLE
#96 Quarkus 3.17+: build error "Missing Javadoc" on config interfaces

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor.adoc
@@ -11,7 +11,7 @@ a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstream
 
 [.description]
 --
-The batch size for processing events in the persistent stream
+Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon framework is used.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -22,12 +22,14 @@ Environment variable: `+++QUARKUS_AXON_PERSISTENTSTREAMS_BATCH_SIZE+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|`100`
+|`-1`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments[`quarkus.axon.persistentstreams.initial-segments`]##
 
 [.description]
 --
+Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_PERSISTENTSTREAMS_INITIAL_SEGMENTS+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor_quarkus.axon.adoc
@@ -11,7 +11,7 @@ a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstream
 
 [.description]
 --
-The batch size for processing events in the persistent stream
+Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon framework is used.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -22,12 +22,14 @@ Environment variable: `+++QUARKUS_AXON_PERSISTENTSTREAMS_BATCH_SIZE+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|`100`
+|`-1`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments[`quarkus.axon.persistentstreams.initial-segments`]##
 
 [.description]
 --
+Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_PERSISTENTSTREAMS_INITIAL_SEGMENTS+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
@@ -11,6 +11,8 @@ a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-batch-size]
 
 [.description]
 --
+Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon framework is used.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_BATCH_SIZE+++[]
@@ -26,6 +28,8 @@ a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-seg
 
 [.description]
 --
+Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_INITIAL_SEGMENTS+++[]
@@ -41,6 +45,8 @@ a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-pos
 
 [.description]
 --
+First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_INITIAL_POSITION+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
@@ -11,6 +11,8 @@ a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-batch-size]
 
 [.description]
 --
+Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon framework is used.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_BATCH_SIZE+++[]
@@ -26,6 +28,8 @@ a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-seg
 
 [.description]
 --
+Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_INITIAL_SEGMENTS+++[]
@@ -41,6 +45,8 @@ a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-pos
 
 [.description]
 --
+First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_INITIAL_POSITION+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor.adoc
@@ -11,6 +11,8 @@ a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-batch-s
 
 [.description]
 --
+Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon framework is used.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_TRACKINGPROCESSOR_BATCH_SIZE+++[]
@@ -26,6 +28,8 @@ a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial
 
 [.description]
 --
+Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_TRACKINGPROCESSOR_INITIAL_SEGMENTS+++[]
@@ -41,6 +45,8 @@ a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial
 
 [.description]
 --
+First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_TRACKINGPROCESSOR_INITIAL_POSITION+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor_quarkus.axon.adoc
@@ -11,6 +11,8 @@ a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-batch-s
 
 [.description]
 --
+Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon framework is used.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_TRACKINGPROCESSOR_BATCH_SIZE+++[]
@@ -26,6 +28,8 @@ a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial
 
 [.description]
 --
+Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_TRACKINGPROCESSOR_INITIAL_SEGMENTS+++[]
@@ -41,6 +45,8 @@ a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial
 
 [.description]
 --
+First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_TRACKINGPROCESSOR_INITIAL_POSITION+++[]

--- a/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamProcessorConf.java
+++ b/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamProcessorConf.java
@@ -47,9 +47,19 @@ public interface PersistentStreamProcessorConf extends EventProcessorConfigurati
     String filter();
 
     /**
-     * The batch size for processing events in the persistent stream
+     * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
+     * framework is used.
      */
-    @WithDefault("100")
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("-1")
     int batchSize();
 
+    /**
+     * Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+     */
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("-1")
+    int initialSegments();
 }

--- a/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamProcessorConf.java
+++ b/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamProcessorConf.java
@@ -50,7 +50,7 @@ public interface PersistentStreamProcessorConf extends EventProcessorConfigurati
      * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
      * framework is used.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("-1")
     int batchSize();
@@ -58,7 +58,7 @@ public interface PersistentStreamProcessorConf extends EventProcessorConfigurati
     /**
      * Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("-1")
     int initialSegments();

--- a/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledProcessorConf.java
+++ b/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledProcessorConf.java
@@ -1,5 +1,6 @@
 package at.meks.quarkiverse.axon.eventprocessor.pooled.runtime;
 
+import at.meks.quarkiverse.axon.eventprocessors.shared.InitialPosition;
 import at.meks.quarkiverse.axon.eventprocessors.shared.StreamingProcessorConf;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -29,4 +30,29 @@ public interface PooledProcessorConf extends StreamingProcessorConf {
      */
     @WithDefault("quarkus-pooled-processor")
     String name();
+
+    /**
+     * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
+     * framework is used.
+     */
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("-1")
+    int batchSize();
+
+    /**
+     * Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+     */
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("-1")
+    int initialSegments();
+
+    /**
+     * First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
+     */
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("tail")
+    InitialPosition initialPosition();
 }

--- a/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledProcessorConf.java
+++ b/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledProcessorConf.java
@@ -35,7 +35,7 @@ public interface PooledProcessorConf extends StreamingProcessorConf {
      * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
      * framework is used.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("-1")
     int batchSize();
@@ -43,7 +43,7 @@ public interface PooledProcessorConf extends StreamingProcessorConf {
     /**
      * Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("-1")
     int initialSegments();
@@ -51,7 +51,7 @@ public interface PooledProcessorConf extends StreamingProcessorConf {
     /**
      * First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("tail")
     InitialPosition initialPosition();

--- a/eventprocessors/shared/src/main/java/at/meks/quarkiverse/axon/eventprocessors/shared/EventProcessorConfiguration.java
+++ b/eventprocessors/shared/src/main/java/at/meks/quarkiverse/axon/eventprocessors/shared/EventProcessorConfiguration.java
@@ -1,19 +1,9 @@
 package at.meks.quarkiverse.axon.eventprocessors.shared;
 
-import io.smallrye.config.WithDefault;
-
 public interface EventProcessorConfiguration {
-    /**
-     * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
-     * framework is used.
-     */
-    @WithDefault("-1")
+
     int batchSize();
 
-    /**
-     * Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
-     */
-    @WithDefault("-1")
     int initialSegments();
 
 }

--- a/eventprocessors/shared/src/main/java/at/meks/quarkiverse/axon/eventprocessors/shared/StreamingProcessorConf.java
+++ b/eventprocessors/shared/src/main/java/at/meks/quarkiverse/axon/eventprocessors/shared/StreamingProcessorConf.java
@@ -1,13 +1,7 @@
 package at.meks.quarkiverse.axon.eventprocessors.shared;
 
-import io.smallrye.config.WithDefault;
-
 public interface StreamingProcessorConf extends EventProcessorConfiguration {
 
-    /**
-     * First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
-     */
-    @WithDefault("tail")
     InitialPosition initialPosition();
 
 }

--- a/eventprocessors/tracking/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/tracking/runtime/TrackingProcessorConf.java
+++ b/eventprocessors/tracking/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/tracking/runtime/TrackingProcessorConf.java
@@ -2,6 +2,7 @@ package at.meks.quarkiverse.axon.eventprocessor.tracking.runtime;
 
 import java.util.concurrent.TimeUnit;
 
+import at.meks.quarkiverse.axon.eventprocessors.shared.InitialPosition;
 import at.meks.quarkiverse.axon.eventprocessors.shared.StreamingProcessorConf;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -24,6 +25,31 @@ public interface TrackingProcessorConf extends StreamingProcessorConf {
      * Sets the time to wait after a failed attempt to claim any token, before making another attempt.
      */
     TokenClaimInterval tokenClaim();
+
+    /**
+     * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
+     * framework is used.
+     */
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("-1")
+    int batchSize();
+
+    /**
+     * Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
+     */
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("-1")
+    int initialSegments();
+
+    /**
+     * First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
+     */
+    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    @Override
+    @WithDefault("tail")
+    InitialPosition initialPosition();
 
     interface TokenClaimInterval {
 

--- a/eventprocessors/tracking/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/tracking/runtime/TrackingProcessorConf.java
+++ b/eventprocessors/tracking/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/tracking/runtime/TrackingProcessorConf.java
@@ -30,7 +30,7 @@ public interface TrackingProcessorConf extends StreamingProcessorConf {
      * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
      * framework is used.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("-1")
     int batchSize();
@@ -38,7 +38,7 @@ public interface TrackingProcessorConf extends StreamingProcessorConf {
     /**
      * Sets the initial number of segments for asynchronous processing. For more information please read axon documentation.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("-1")
     int initialSegments();
@@ -46,7 +46,7 @@ public interface TrackingProcessorConf extends StreamingProcessorConf {
     /**
      * First token to read. This can be number of the token where should be started, or HEAD, or TAIL.
      */
-    // Sadly, since Quarkus 3.17 inheritance of the Super-Interface doesn't work anymore and leads to build errors: Missing javadoc
+    // Sadly, the inheritance of the Super-Interface doesn't work and leads to build errors: Missing javadoc
     @Override
     @WithDefault("tail")
     InitialPosition initialPosition();


### PR DESCRIPTION
The inheritances of interfaces are not recognized by the quarkus-config-doc-maven-plugin. Therefore, the documentation for these config properties hasn't generated.