### PR TITLE
Add support for query and event interceptors and exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ You can provide your own setup for
 * JDBC Token Store
 * custom setup for Tokenstore
 
+### Interceptors
+
+* command dispatch and handler interceptors
+* query dispatch and handler interceptors
+
+### Exceptions Handling
+
+* wrapping Exceptions into CommandExecutionException
+* wrapping Exceptions into QueryExecutionException
+
 ### other supported stuff
 
 * transaction handling
@@ -84,10 +94,7 @@ You can provide your own setup for
 * dev service for the axon server
 * live reloading
 * snapshots
-* command dispatch interceptors
-* command handler interceptors
-* wrapping Exceptions into CommandExecutionException
-* wrapping Exceptions into QueryExecutionException
+
 
 #### Live reloading
 Live reloading works with a schedule process, which checks if sources changed.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can provide your own setup for
 
 * command dispatch and handler interceptors
 * query dispatch and handler interceptors
-* event dispatch interceptors
+* event dispatch and default handler interceptors
 
 ### Exceptions Handling
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You can provide your own setup for
 * command dispatch interceptors
 * command handler interceptors
 * wrapping Exceptions into CommandExecutionException
+* wrapping Exceptions into QueryExecutionException
 
 #### Live reloading
 Live reloading works with a schedule process, which checks if sources changed.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can provide your own setup for
 * snapshots
 * command dispatch interceptors
 * command handler interceptors
+* wrapping Exceptions into CommandExecutionException
 
 #### Live reloading
 Live reloading works with a schedule process, which checks if sources changed.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can provide your own setup for
 
 * command dispatch and handler interceptors
 * query dispatch and handler interceptors
+* event dispatch interceptors
 
 ### Exceptions Handling
 

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/command/CommandExceptionInterceptorTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/command/CommandExceptionInterceptorTest.java
@@ -1,0 +1,39 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.command;
+
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.axonframework.commandhandling.CommandExecutionException;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.model.Api;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CommandExceptionInterceptorTest {
+
+    @Inject
+    CommandGateway commandGateway;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(JavaArchiveTest::javaArchiveBase);
+
+    @Test
+    void onExceptionWhenCommandIsHandled() {
+        var cardId = UUID.randomUUID().toString();
+        commandGateway.sendAndWait(new Api.IssueCardCommand(cardId, 10));
+        commandGateway.sendAndWait(new Api.RedeemCardCommand(cardId, 1));
+        assertThatException()
+                .isThrownBy(() -> commandGateway.sendAndWait(new Api.RedeemCardCommand(cardId, 10)))
+                .isInstanceOf(CommandExecutionException.class)
+                .withMessageContaining(
+                        "error while executing command handler for command at.meks.quarkiverse.axon.shared.model.Api$RedeemCardCommand")
+                .withStackTraceContaining("amount must be less than current card amount");
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/command/NoCommandExceptionInterceptorTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/command/NoCommandExceptionInterceptorTest.java
@@ -1,0 +1,40 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.command;
+
+import static at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest.javaArchiveBase;
+import static at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest.propertiesFile;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.model.Api;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoCommandExceptionInterceptorTest {
+
+    @Inject
+    CommandGateway commandGateway;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> javaArchiveBase()
+                    .addAsResource(
+                            propertiesFile("/interceptor.command/noCommandExceptionInterceptor.properties"),
+                            "application.properties"));
+
+    @Test
+    void onExceptionWhenCommandIsHandled() {
+        var cardId = UUID.randomUUID().toString();
+        commandGateway.sendAndWait(new Api.IssueCardCommand(cardId, 10));
+        commandGateway.sendAndWait(new Api.RedeemCardCommand(cardId, 1));
+        assertThatException()
+                .isThrownBy(() -> commandGateway.sendAndWait(new Api.RedeemCardCommand(cardId, 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .withMessageContaining("amount must be less than current card amount");
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/MoreDispatchInterceptorProducersTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/MoreDispatchInterceptorProducersTest.java
@@ -1,0 +1,48 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.event;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.runtime.customizations.EventDispatchInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MoreDispatchInterceptorProducersTest extends JavaArchiveTest {
+
+    @ApplicationScoped
+    public static class InterceptorsProducer1 implements EventDispatchInterceptorsProducer {
+
+        @Override
+        public List<MessageDispatchInterceptor<EventMessage<?>>> createDispatchInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer2 implements EventDispatchInterceptorsProducer {
+
+        @Override
+        public List<MessageDispatchInterceptor<EventMessage<?>>> createDispatchInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    private static @NotNull MessageDispatchInterceptor<EventMessage<?>> interceptor() {
+        return messages -> (index, eventMessage) -> eventMessage;
+    }
+
+    @RegisterExtension()
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class, true)
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer1.class, InterceptorsProducer2.class));
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/MoreHandlerInterceptorProducersTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/MoreHandlerInterceptorProducersTest.java
@@ -1,0 +1,48 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.event;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.runtime.customizations.EventHandlerInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MoreHandlerInterceptorProducersTest extends JavaArchiveTest {
+
+    @ApplicationScoped
+    public static class InterceptorsProducer1 implements EventHandlerInterceptorsProducer {
+
+        @Override
+        public List<MessageHandlerInterceptor<EventMessage<?>>> createHandlerInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer2 implements EventHandlerInterceptorsProducer {
+
+        @Override
+        public List<MessageHandlerInterceptor<EventMessage<?>>> createHandlerInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    private static @NotNull MessageHandlerInterceptor<EventMessage<?>> interceptor() {
+        return (unitOfWork, interceptorChain) -> interceptorChain.proceed();
+    }
+
+    @RegisterExtension()
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class, true)
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer1.class, InterceptorsProducer2.class));
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/OneDispatchInterceptorProducerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/OneDispatchInterceptorProducerTest.java
@@ -1,0 +1,68 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.event;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import at.meks.quarkiverse.axon.runtime.customizations.EventDispatchInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OneDispatchInterceptorProducerTest extends JavaArchiveTest {
+
+    private static final Logger LOGGER = Mockito.mock(Logger.class);
+
+    public static class LoggerProducer {
+
+        @Produces
+        public Logger logger() {
+            return LOGGER;
+        }
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer implements EventDispatchInterceptorsProducer {
+
+        private final Logger logger;
+
+        public InterceptorsProducer(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public List<MessageDispatchInterceptor<EventMessage<?>>> createDispatchInterceptor() {
+            return List.of(interceptor("Interceptor 1"), interceptor("Interceptor 2"));
+        }
+
+        private @NotNull MessageDispatchInterceptor<EventMessage<?>> interceptor(String interceptorName) {
+            return messages -> (index, event) -> {
+                logger.debug(interceptorName + " logs event");
+                return event;
+            };
+        }
+
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer.class, LoggerProducer.class));
+
+    @Override
+    protected void assertOthers() {
+        InOrder inOrder = Mockito.inOrder(LOGGER);
+        inOrder.verify(LOGGER).debug("Interceptor 1 logs event");
+        inOrder.verify(LOGGER).debug("Interceptor 2 logs event");
+        inOrder.verify(LOGGER).debug("Interceptor 1 logs event");
+        inOrder.verify(LOGGER).debug("Interceptor 2 logs event");
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/OneHandlerInterceptorProducerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/event/OneHandlerInterceptorProducerTest.java
@@ -1,0 +1,68 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.event;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import at.meks.quarkiverse.axon.runtime.customizations.EventHandlerInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OneHandlerInterceptorProducerTest extends JavaArchiveTest {
+
+    private static final Logger LOGGER = Mockito.mock(Logger.class);
+
+    public static class LoggerProducer {
+
+        @Produces
+        public Logger logger() {
+            return LOGGER;
+        }
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer implements EventHandlerInterceptorsProducer {
+
+        private final Logger logger;
+
+        public InterceptorsProducer(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public List<MessageHandlerInterceptor<EventMessage<?>>> createHandlerInterceptor() {
+            return List.of(interceptor("Interceptor 1"), interceptor("Interceptor 2"));
+        }
+
+        private @NotNull MessageHandlerInterceptor<EventMessage<?>> interceptor(String interceptorName) {
+            return (unitOfWork, interceptorChain) -> {
+                logger.debug(interceptorName + " logs event");
+                return interceptorChain.proceed();
+            };
+        }
+
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer.class, LoggerProducer.class));
+
+    @Override
+    protected void assertOthers() {
+        InOrder inOrder = Mockito.inOrder(LOGGER);
+        inOrder.verify(LOGGER).debug("Interceptor 1 logs event");
+        inOrder.verify(LOGGER).debug("Interceptor 2 logs event");
+        inOrder.verify(LOGGER).debug("Interceptor 1 logs event");
+        inOrder.verify(LOGGER).debug("Interceptor 2 logs event");
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/MoreDispatchInterceptorProducersTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/MoreDispatchInterceptorProducersTest.java
@@ -1,0 +1,48 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.query;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.queryhandling.QueryMessage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.runtime.customizations.QueryDispatchInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MoreDispatchInterceptorProducersTest extends JavaArchiveTest {
+
+    @ApplicationScoped
+    public static class InterceptorsProducer1 implements QueryDispatchInterceptorsProducer {
+
+        @Override
+        public List<MessageDispatchInterceptor<QueryMessage<?, ?>>> createDispatchInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer2 implements QueryDispatchInterceptorsProducer {
+
+        @Override
+        public List<MessageDispatchInterceptor<QueryMessage<?, ?>>> createDispatchInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    private static @NotNull MessageDispatchInterceptor<QueryMessage<?, ?>> interceptor() {
+        return messages -> (index, query) -> query;
+    }
+
+    @RegisterExtension()
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class, true)
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer1.class, InterceptorsProducer2.class));
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/MoreHandlerInterceptorProducersTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/MoreHandlerInterceptorProducersTest.java
@@ -1,0 +1,48 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.query;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.queryhandling.QueryMessage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.runtime.customizations.QueryHandlerInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MoreHandlerInterceptorProducersTest extends JavaArchiveTest {
+
+    @ApplicationScoped
+    public static class InterceptorsProducer1 implements QueryHandlerInterceptorsProducer {
+
+        @Override
+        public List<MessageHandlerInterceptor<QueryMessage<?, ?>>> createHandlerInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer2 implements QueryHandlerInterceptorsProducer {
+
+        @Override
+        public List<MessageHandlerInterceptor<QueryMessage<?, ?>>> createHandlerInterceptor() {
+            return List.of(interceptor());
+        }
+
+    }
+
+    private static @NotNull MessageHandlerInterceptor<QueryMessage<?, ?>> interceptor() {
+        return (unitOfWork, interceptorChain) -> interceptorChain.proceed();
+    }
+
+    @RegisterExtension()
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class, true)
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer1.class, InterceptorsProducer2.class));
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/NoQueryExceptionInterceptorTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/NoQueryExceptionInterceptorTest.java
@@ -1,0 +1,55 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.query;
+
+import static at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest.propertiesFile;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.queryhandling.QueryHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoQueryExceptionInterceptorTest {
+
+    @Inject
+    QueryGateway queryGateway;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(FaultyQueryHandler.class, FaultyQuery.class)
+                    .addAsResource(propertiesFile("/interceptor/query/noQueryExceptionInterceptor.properties"),
+                            "application.properties"));
+
+    record FaultyQuery(String id) {
+    }
+
+    @Unremovable
+    @ApplicationScoped
+    static class FaultyQueryHandler {
+
+        @QueryHandler
+        public Object handle(FaultyQuery query) {
+            throw new IllegalStateException("oops, I did it again");
+        }
+    }
+
+    @Test
+    void onExceptionWhenCommandIsHandled() {
+        assertThatException()
+                .isThrownBy(() -> queryGateway.query(new FaultyQuery(UUID.randomUUID().toString()), Object.class).get())
+                .isInstanceOf(ExecutionException.class)
+                .havingCause()
+                .isInstanceOf(IllegalStateException.class)
+                .withMessageContaining("oops, I did it again");
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/OneDispatchInterceptorProducerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/OneDispatchInterceptorProducerTest.java
@@ -1,0 +1,66 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.query;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.queryhandling.QueryMessage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import at.meks.quarkiverse.axon.runtime.customizations.QueryDispatchInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OneDispatchInterceptorProducerTest extends JavaArchiveTest {
+
+    private static final Logger LOGGER = Mockito.mock(Logger.class);
+
+    public static class LoggerProducer {
+
+        @Produces
+        public Logger logger() {
+            return LOGGER;
+        }
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer implements QueryDispatchInterceptorsProducer {
+
+        private final Logger logger;
+
+        public InterceptorsProducer(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public List<MessageDispatchInterceptor<QueryMessage<?, ?>>> createDispatchInterceptor() {
+            return List.of(interceptor("Interceptor 1"), interceptor("Interceptor 2"));
+        }
+
+        private @NotNull MessageDispatchInterceptor<QueryMessage<?, ?>> interceptor(String interceptorName) {
+            return messages -> (index, query) -> {
+                logger.debug(interceptorName + " logs query");
+                return query;
+            };
+        }
+
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer.class, LoggerProducer.class));
+
+    @Override
+    protected void assertOthers() {
+        InOrder inOrder = Mockito.inOrder(LOGGER);
+        inOrder.verify(LOGGER).debug("Interceptor 1 logs query");
+        inOrder.verify(LOGGER).debug("Interceptor 2 logs query");
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/OneHandlerInterceptorProducerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/OneHandlerInterceptorProducerTest.java
@@ -1,0 +1,66 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.query;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.queryhandling.QueryMessage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import at.meks.quarkiverse.axon.runtime.customizations.QueryHandlerInterceptorsProducer;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OneHandlerInterceptorProducerTest extends JavaArchiveTest {
+
+    private static final Logger LOGGER = Mockito.mock(Logger.class);
+
+    public static class LoggerProducer {
+
+        @Produces
+        public Logger logger() {
+            return LOGGER;
+        }
+    }
+
+    @ApplicationScoped
+    public static class InterceptorsProducer implements QueryHandlerInterceptorsProducer {
+
+        private final Logger logger;
+
+        public InterceptorsProducer(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public List<MessageHandlerInterceptor<QueryMessage<?, ?>>> createHandlerInterceptor() {
+            return List.of(interceptor("Interceptor 1"), interceptor("Interceptor 2"));
+        }
+
+        private @NotNull MessageHandlerInterceptor<QueryMessage<?, ?>> interceptor(String interceptorName) {
+            return (unitOfWork, interceptorChain) -> {
+                logger.debug(interceptorName + " logs query");
+                return interceptorChain.proceed();
+            };
+        }
+
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(InterceptorsProducer.class, LoggerProducer.class));
+
+    @Override
+    protected void assertOthers() {
+        InOrder inOrder = Mockito.inOrder(LOGGER);
+        inOrder.verify(LOGGER).debug("Interceptor 1 logs query");
+        inOrder.verify(LOGGER).debug("Interceptor 2 logs query");
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/QueryExceptionInterceptorTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/interceptor/query/QueryExceptionInterceptorTest.java
@@ -1,0 +1,55 @@
+package at.meks.quarkiverse.axon.deployment.interceptor.query;
+
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.axonframework.queryhandling.QueryExecutionException;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.queryhandling.QueryHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QueryExceptionInterceptorTest {
+
+    @Inject
+    QueryGateway queryGateway;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(FaultyQueryHandler.class, FaultyQuery.class));
+
+    record FaultyQuery(String id) {
+    }
+
+    @Unremovable
+    @ApplicationScoped
+    static class FaultyQueryHandler {
+
+        @QueryHandler
+        public Object handle(FaultyQuery query) {
+            throw new IllegalArgumentException("oops, I did it again");
+        }
+    }
+
+    @Test
+    void onExceptionWhenCommandIsHandled() {
+        assertThatException()
+                .isThrownBy(() -> queryGateway.query(new FaultyQuery(UUID.randomUUID().toString()), Object.class).get())
+                .isInstanceOf(ExecutionException.class)
+                .havingCause()
+                .isInstanceOf(QueryExecutionException.class)
+                .withMessageContaining(
+                        "error while executing query handler for query at.meks.quarkiverse.axon.deployment.interceptor.query.QueryExceptionInterceptorTest$FaultyQuery")
+                .withStackTraceContaining("oops, I did it again");
+    }
+}

--- a/core/deployment/src/test/resources/interceptor.command/noCommandExceptionInterceptor.properties
+++ b/core/deployment/src/test/resources/interceptor.command/noCommandExceptionInterceptor.properties
@@ -1,0 +1,1 @@
+quarkus.axon.exception-handling.wrap-on-command-handler=false

--- a/core/deployment/src/test/resources/interceptor/query/noQueryExceptionInterceptor.properties
+++ b/core/deployment/src/test/resources/interceptor/query/noQueryExceptionInterceptor.properties
@@ -1,0 +1,1 @@
+quarkus.axon.exception-handling.wrap-on-query-handler=false

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
@@ -111,6 +111,11 @@ public interface AxonConfiguration {
         @WithDefault("true")
         boolean wrapOnCommandHandler();
 
+        /**
+         * if true, the thrown exception will be wrapped into the recommended QueryExecutionException.
+         */
+        @WithDefault("true")
+        boolean wrapOnQueryHandler();
     }
 
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
@@ -36,6 +36,11 @@ public interface AxonConfiguration {
     LiveReloadConfig liveReload();
 
     /**
+     * Configuration for Exception Handling in the Axon framework.
+     */
+    ExceptionHandlingConfig exceptionHandling();
+
+    /**
      * Live reloading needs a wait time, to wait for axon's framework or axon's server to cleanup. This wait time seems
      * to be dependent on the hardware. The default configuration works well on a MacBook Pro with M1 Chip.
      * If you get the error that no command handler is available after a reload, increase the wait time until this
@@ -97,4 +102,15 @@ public interface AxonConfiguration {
         int threshold();
 
     }
+
+    interface ExceptionHandlingConfig {
+
+        /**
+         * if true, the thrown exception will be wrapped into the recommended CommandExecutionException.
+         */
+        @WithDefault("true")
+        boolean wrapOnCommandHandler();
+
+    }
+
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventDispatchInterceptorsProducer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventDispatchInterceptorsProducer.java
@@ -1,0 +1,27 @@
+package at.meks.quarkiverse.axon.runtime.customizations;
+
+import java.util.List;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+
+/**
+ * This interface defines a contract for producing a list of event message dispatch interceptors.
+ * <p>
+ * Implementations of this interface can be used to customize the behavior of how
+ * event messages are processed or modified during their dispatch.
+ */
+public interface EventDispatchInterceptorsProducer {
+
+    /**
+     * Creates and returns a list of {@link MessageDispatchInterceptor} instances
+     * for use with {@link EventMessage} dispatching.
+     * <p>
+     * These interceptors can be applied to the interception and potential modification
+     * of {@link EventMessage} instances before they are dispatched for handling.
+     *
+     * @return a list of message dispatch interceptors for event messages.
+     */
+    List<MessageDispatchInterceptor<EventMessage<?>>> createDispatchInterceptor();
+
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventHandlerInterceptorsProducer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventHandlerInterceptorsProducer.java
@@ -1,0 +1,25 @@
+package at.meks.quarkiverse.axon.runtime.customizations;
+
+import java.util.List;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageHandlerInterceptor;
+
+/**
+ * Provides a mechanism for creating a list of event handler interceptors.
+ * Interceptors are used to add additional behavior or logic during the
+ * processing of event messages in Axon Framework.
+ */
+public interface EventHandlerInterceptorsProducer {
+
+    /**
+     * Creates a list of message handler interceptors for event messages.
+     * These interceptors can be used to influence the event handling process,
+     * such as pre-processing, validation, or custom logic.
+     *
+     * @return a list of {@link MessageHandlerInterceptor} objects
+     *         for handling {@link EventMessage} instances.
+     */
+    List<MessageHandlerInterceptor<EventMessage<?>>> createHandlerInterceptor();
+
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/QueryDispatchInterceptorsProducer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/QueryDispatchInterceptorsProducer.java
@@ -1,0 +1,24 @@
+package at.meks.quarkiverse.axon.runtime.customizations;
+
+import java.util.List;
+
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.queryhandling.QueryMessage;
+
+/**
+ * A producer interface for creating command dispatch interceptors in Axon Framework.
+ * Implementations of this interface are responsible for defining
+ * and returning a list of dispatch interceptors that can intercept
+ * and modify command messages during the dispatch process.
+ */
+public interface QueryDispatchInterceptorsProducer {
+
+    /**
+     * Creates and returns a list of dispatch interceptors to be applied to query messages.
+     * Dispatch interceptors can be used to inspect or modify query messages before they are dispatched.
+     *
+     * @return a list of {@link MessageDispatchInterceptor} instances for query messages
+     */
+    List<MessageDispatchInterceptor<QueryMessage<?, ?>>> createDispatchInterceptor();
+
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/QueryHandlerInterceptorsProducer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/QueryHandlerInterceptorsProducer.java
@@ -1,0 +1,25 @@
+package at.meks.quarkiverse.axon.runtime.customizations;
+
+import java.util.List;
+
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.queryhandling.QueryMessage;
+
+/**
+ * Provides a mechanism for creating a list of query handler interceptors.
+ * Interceptors are used to add additional behavior or logic during the
+ * processing of query messages in Axon Framework.
+ */
+public interface QueryHandlerInterceptorsProducer {
+
+    /**
+     * Creates a list of message handler interceptors for query messages.
+     * These interceptors can be used to influence the query handling process,
+     * such as pre-processing, validation, or custom logic.
+     *
+     * @return a list of {@link MessageHandlerInterceptor} objects
+     *         for handling {@link QueryMessage} instances.
+     */
+    List<MessageHandlerInterceptor<QueryMessage<?, ?>>> createHandlerInterceptor();
+
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
@@ -63,6 +63,9 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
     Instance<QueryDispatchInterceptorsProducer> queryDispatchInterceptorProducers;
 
     @Inject
+    Instance<QueryHandlerInterceptorsProducer> queryHandlerInterceptorProducers;
+
+    @Inject
     AxonConfiguration axonConfiguration;
 
     private Set<Class<?>> aggregateClasses;
@@ -193,6 +196,14 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
 
     private void configureQueryHandlerInterceptors(QueryBus queryBus) {
         configureQueryExceptionInterceptors(queryBus);
+        if (queryHandlerInterceptorProducers.isAmbiguous()) {
+            throw new IllegalStateException("multiple implementations of %s found: %s".formatted(
+                    QueryHandlerInterceptorsProducer.class.getName(),
+                    toCsv(queryHandlerInterceptorProducers.stream())));
+        } else if (queryHandlerInterceptorProducers.isResolvable()) {
+            queryHandlerInterceptorProducers.get().createHandlerInterceptor()
+                    .forEach(queryBus::registerHandlerInterceptor);
+        }
     }
 
     private void configureQueryExceptionInterceptors(QueryBus queryBus) {

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -92,6 +92,23 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler[`quarkus.axon.exception-handling.wrap-on-query-handler`]##
+
+[.description]
+--
+if true, the thrown exception will be wrapped into the recommended QueryExecutionException.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_QUERY_HANDLER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_QUERY_HANDLER+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 
 `quarkus.axon.snapshots."aggregate-name".trigger-type`

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -75,6 +75,23 @@ endif::add-copy-button-to-env-var[]
 |long
 |`500`
 
+a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler[`quarkus.axon.exception-handling.wrap-on-command-handler`]##
+
+[.description]
+--
+if true, the thrown exception will be wrapped into the recommended CommandExecutionException.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_COMMAND_HANDLER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_COMMAND_HANDLER+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 
 `quarkus.axon.snapshots."aggregate-name".trigger-type`

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -92,6 +92,23 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler[`quarkus.axon.exception-handling.wrap-on-query-handler`]##
+
+[.description]
+--
+if true, the thrown exception will be wrapped into the recommended QueryExecutionException.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_QUERY_HANDLER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_QUERY_HANDLER+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 
 `quarkus.axon.snapshots."aggregate-name".trigger-type`

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -75,6 +75,23 @@ endif::add-copy-button-to-env-var[]
 |long
 |`500`
 
+a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler[`quarkus.axon.exception-handling.wrap-on-command-handler`]##
+
+[.description]
+--
+if true, the thrown exception will be wrapped into the recommended CommandExecutionException.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_COMMAND_HANDLER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_EXCEPTION_HANDLING_WRAP_ON_COMMAND_HANDLER+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 
 `quarkus.axon.snapshots."aggregate-name".trigger-type`

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -571,11 +571,22 @@ For more information on setting up a token store, please read the Axon framework
 
 Automatically all Exceptions, which are thrown in Command-Handler-Methods, are wrapped into `CommandExecutionException`.
 
-To disable this feature set the following configuration variable:
+To disable this feature, set the following configuration variable:
 
 [source,properties]
 ----
 quarkus.axon.exception-handling.wrap-on-command-handler=false
+----
+
+==== Handling Exceptions in Query Handler
+
+Automatically all Exceptions, which are thrown in Query-Handler-Methods, are wrapped into `QueryExecutionException`.
+
+To disable this feature, set the following configuration variable:
+
+[source,properties]
+----
+quarkus.axon.exception-handling.wrap-on-query-handler=false
 ----
 
 === Interceptors

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -668,10 +668,17 @@ In the same way as for <<_command_handler_interceptor>> you can implement an int
 
 The interface you have to implement is ´QueryHandlerInterceptorsProducer´.
 
-==== Query Dispatch Interceptors
+==== Event Dispatch Interceptors
 In the same way as for <<_command_dispatch_interceptors_>> you can implement an interceptor when events are dispatched.
 
 The interface you have to implement is ´EventDispatchInterceptorsProducer´.
+
+==== Event Handler Interceptors
+In the same way as for <<_command_handler_interceptor>> you can implement an interceptor when events are handled.
+
+The interface you have to implement is ´EventHandlerInterceptorsProducer´.
+
+These interceptors are registered for each event processor.
 
 === Transaction
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -565,6 +565,19 @@ public class MyCustomTokenStoreConfigurer implements TokenStoreConfigurer {
 
 For more information on setting up a token store, please read the Axon framework documentation.
 
+=== Exception Handling
+
+==== Handling Exceptions in Command Handler
+
+Automatically all Exceptions, which are thrown in Command-Handler-Methods, are wrapped into `CommandExecutionException`.
+
+To disable this feature set the following configuration variable:
+
+[source,properties]
+----
+quarkus.axon.exception-handling.wrap-on-command-handler=false
+----
+
 === Interceptors
 ==== Command Dispatch Interceptors
 If you'd like to set up command dispatch interceptors, you have to implement `CommandDispatchInterceptorsProducer`. The method of the interface returns a list of interceptors in the order they should be invoked.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -590,12 +590,13 @@ quarkus.axon.exception-handling.wrap-on-query-handler=false
 ----
 
 === Interceptors
+[#_command_dispatch_interceptors_]
 ==== Command Dispatch Interceptors
-If you'd like to set up command dispatch interceptors, you have to implement `CommandDispatchInterceptorsProducer`. The method of the interface returns a list of interceptors in the order they should be invoked.
+If you'd like to set up command dispatch interceptors, you have to implement `CommandDispatchInterceptorsProducer`.The method of the interface returns a list of interceptors in the order they should be invoked.
 
 A simple example would be to log each command message, which was dispatched to the command bus.
 
-[source, java]
+[source,java]
 ----
 @ApplicationScoped
 public static class MyCommandDispatchInterceptorsProducer implements CommandDispatchInterceptorsProducer {
@@ -619,9 +620,10 @@ Another use case could be the structural validation of the command using Bean Va
 
 Please read the Axon framework documentation for details about the Command disptach interceptor.
 
+[#_command_handler_interceptor]
 ==== Command Handler Interceptor
 
-If you'd like to set up command handler interceptors, you have to implement `CommandHandlerInterceptorsProducer`. The method of the interface returns a list of interceptors in the order they should be invoked.
+If you'd like to set up command handler interceptors, you have to implement `CommandHandlerInterceptorsProducer`.The method of the interface returns a list of interceptors in the order they should be invoked.
 
 Example:
 
@@ -656,7 +658,18 @@ public static class MyCommandHandlerInterceptorsProducer implements CommandHandl
 
 For more details about command handler interceptors, please read the Axon framework documentation.
 
+==== Query Dispatch Interceptors
+In the same way as for <<_command_dispatch_interceptors_>> you can implement an interceptor when queries are dispatched.
+
+The interface you have to implement is ´QueryDispatchInterceptorsProducer´.
+
+==== Query Handler Interceptors
+In the same way as for <<_command_handler_interceptor>> you can implement an interceptor when queries are handled.
+
+The interface you have to implement is ´QueryHandlerInterceptorsProducer´.
+
 === Transaction
+
 CAUTION: By default, no transaction management is setup.
 
 If you need transaction management you can simple add the extension:

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -668,11 +668,16 @@ In the same way as for <<_command_handler_interceptor>> you can implement an int
 
 The interface you have to implement is ´QueryHandlerInterceptorsProducer´.
 
+==== Query Dispatch Interceptors
+In the same way as for <<_command_dispatch_interceptors_>> you can implement an interceptor when events are dispatched.
+
+The interface you have to implement is ´EventDispatchInterceptorsProducer´.
+
 === Transaction
 
 CAUTION: By default, no transaction management is setup.
 
-If you need transaction management you can simple add the extension:
+If you need transaction management, you can add the extension:
 
 [source,xml]
 ----

--- a/integration-tests/src/main/java/at/meks/quarkiverse/axon/it/GiftcardResource.java
+++ b/integration-tests/src/main/java/at/meks/quarkiverse/axon/it/GiftcardResource.java
@@ -37,8 +37,15 @@ public class GiftcardResource {
             commandGateway.sendAndWait(new Api.IssueCardCommand(cardId, initialAmount));
             return Response.noContent().build();
         } catch (Exception e) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(e.getCause().getMessage()).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(toResponseEntity(e)).build();
         }
+    }
+
+    private static String toResponseEntity(Exception e) {
+        if (e.getCause() == null) {
+            return e.getMessage();
+        }
+        return e.getMessage() + "; " + e.getCause().getMessage();
     }
 
     @PUT
@@ -48,7 +55,7 @@ public class GiftcardResource {
             commandGateway.sendAndWait(new Api.RedeemCardCommand(cardId, amount));
             return Response.noContent().build();
         } catch (Exception e) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(e.getCause().getMessage()).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(toResponseEntity(e)).build();
         }
     }
 
@@ -59,7 +66,7 @@ public class GiftcardResource {
             commandGateway.sendAndWait(new Api.UndoLatestRedemptionCommand(cardId, amount));
             return Response.noContent().build();
         } catch (Exception e) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(e.getCause().getMessage()).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(toResponseEntity(e)).build();
         }
     }
 }

--- a/integration-tests/src/test/java/at/meks/quarkiverse/axon/it/ApplicationTest.java
+++ b/integration-tests/src/test/java/at/meks/quarkiverse/axon/it/ApplicationTest.java
@@ -44,12 +44,14 @@ class ApplicationTest {
         redeemCard(3);
 
         assertThatException().isThrownBy(() -> redeemCard(12))
-                .withMessageContaining("must be less than current card amount");
+                .withMessageContaining("must be less than current card amount")
+                .withMessageContaining("RedeemCardCommand");
 
         undoLatestRedemption(3);
 
         assertThatException().isThrownBy(() -> undoLatestRedemption(2))
-                .withMessageContaining("amount must be the lastest redeem amount");
+                .withMessageContaining("amount must be the lastest redeem amount")
+                .withMessageContaining("UndoLatestRedemptionCommand");
 
         assertCurrentAmount(14);
         assertAtLeastOneSnaptshotExists();

--- a/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/model/DomainServiceExample.java
+++ b/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/model/DomainServiceExample.java
@@ -3,9 +3,7 @@ package at.meks.quarkiverse.axon.shared.model;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.commandhandling.CommandHandler;
-import org.axonframework.messaging.interceptors.ExceptionHandler;
 import org.axonframework.modelling.command.Aggregate;
 import org.axonframework.modelling.command.Repository;
 
@@ -25,11 +23,6 @@ public class DomainServiceExample {
     void handle(Api.RedeemCardCommand command) {
         Aggregate<Giftcard> giftcardAggregate = giftcardRepository.load(command.id());
         giftcardAggregate.execute(giftcard -> giftcard.requestRedeem(command.amount()));
-    }
-
-    @ExceptionHandler
-    public void handleAll(Exception exception) {
-        throw new CommandExecutionException("wrapped exception in details", exception);
     }
 
 }

--- a/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/model/Giftcard.java
+++ b/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/model/Giftcard.java
@@ -6,10 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.eventsourcing.EventSourcingHandler;
-import org.axonframework.messaging.interceptors.ExceptionHandler;
 import org.axonframework.modelling.command.AggregateIdentifier;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -82,8 +80,4 @@ public class Giftcard {
         this.currentAmount += event.amount();
     }
 
-    @ExceptionHandler
-    public void handleAll(Exception exception) {
-        throw new CommandExecutionException("wrapped exception in details", exception);
-    }
 }


### PR DESCRIPTION
This pull request introduces support for query and event interceptors through the interfaces

* `QueryDispatchInterceptorsProducer`
* `QueryHandlerInterceptorsProducer`
* `EventDispatchInterceptorsProducer`
* `EventHandlerInterceptorsProducer`

It also enhances exception handling by wrapping exceptions in

* query handlers with `QueryExecutionException`.
* command handlers with `CommandExecutionException`

A configuration option to disable exception wrapping is included.