### PR TITLE
Persistent stream bug

### DIFF
--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/AxonEventProcessingConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/AxonEventProcessingConfigurer.java
@@ -1,5 +1,7 @@
 package at.meks.quarkiverse.axon.runtime.customizations;
 
+import java.util.Collection;
+
 import org.axonframework.config.EventProcessingConfigurer;
 
 /**
@@ -15,7 +17,8 @@ public interface AxonEventProcessingConfigurer {
      * such as event processors, within the Axon Framework's configuration.
      *
      * @param configurer the {@link EventProcessingConfigurer} to be customized
+     * @param eventhandlers all discovered eventhandler instances of the application
      */
-    void configure(EventProcessingConfigurer configurer);
+    void configure(EventProcessingConfigurer configurer, Collection<Object> eventhandlers);
 
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
@@ -113,7 +113,7 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
                         "multiple eventProcessingConfigurers(" + AxonEventProcessingConfigurer.class.getName() + ") found.");
             }
             tokenStoreConfigurer.configureTokenStore(configurer);
-            eventProcessingConfigurers.get().configure(configurer.eventProcessing());
+            eventProcessingConfigurers.get().configure(configurer.eventProcessing(), eventhandlers);
 
             eventhandlers.forEach(handler -> registerEventHandler(handler, configurer));
         }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/SubscribingEventProcessorConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/SubscribingEventProcessorConfigurer.java
@@ -1,5 +1,7 @@
 package at.meks.quarkiverse.axon.runtime.defaults;
 
+import java.util.Collection;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.axonframework.config.EventProcessingConfigurer;
@@ -12,7 +14,7 @@ import io.quarkus.arc.DefaultBean;
 public class SubscribingEventProcessorConfigurer implements AxonEventProcessingConfigurer {
 
     @Override
-    public void configure(EventProcessingConfigurer configurer) {
+    public void configure(EventProcessingConfigurer configurer, Collection<Object> eventhandlers) {
         configurer.usingSubscribingEventProcessors();
     }
 }

--- a/eventprocessors/persistentstream/deployment/src/test/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/deployment/WithDefaultsTest.java
+++ b/eventprocessors/persistentstream/deployment/src/test/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/deployment/WithDefaultsTest.java
@@ -8,6 +8,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class WithDefaultsTest extends PersistentStreamProcessorTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = JavaArchiveTest.application(JavaArchiveTest.javaArchiveBase());
+    static final QuarkusUnitTest config = JavaArchiveTest.application(JavaArchiveTest.javaArchiveBase()
+            .addAsResource(propertiesFile("/withDefaults.properties"), "application.properties"));
 
 }

--- a/eventprocessors/persistentstream/deployment/src/test/resources/propertiesChanged.properties
+++ b/eventprocessors/persistentstream/deployment/src/test/resources/propertiesChanged.properties
@@ -1,3 +1,4 @@
+quarkus.axon.axon-application-name=PersistentStreamsTestPropChanges
 quarkus.axon.persistentstreams.filter=aggregateType="Giftcard"
 quarkus.axon.persistentstreams.batch-size=50
 quarkus.axon.persistentstreams.initial-position=HEAD

--- a/eventprocessors/persistentstream/deployment/src/test/resources/withDefaults.properties
+++ b/eventprocessors/persistentstream/deployment/src/test/resources/withDefaults.properties
@@ -1,0 +1,1 @@
+quarkus.axon.axon-application-name=PersistentStreamsTestDefaults

--- a/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamEventProcessingConfigurer.java
+++ b/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamEventProcessingConfigurer.java
@@ -41,8 +41,12 @@ public class PersistentStreamEventProcessingConfigurer implements AxonEventProce
         packagesOfEventhandlers(eventhandlers)
                 .forEach(pkgName -> configurer.registerSubscribingEventProcessor(pkgName,
                         conf -> createPersistentStreamMessageSource(
-                                pkgName, conf,
-                                persistentStreamProperties(axonConfiguration.axonApplicationName() + "-" + pkgName))));
+                                eventprocessorName(pkgName), conf,
+                                persistentStreamProperties(eventprocessorName(pkgName)))));
+    }
+
+    private String eventprocessorName(String pkgName) {
+        return axonConfiguration.axonApplicationName() + "-" + pkgName;
     }
 
     private PersistentStreamMessageSource createPersistentStreamMessageSource(String pkgName, Configuration conf,

--- a/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamEventProcessingConfigurer.java
+++ b/eventprocessors/persistentstream/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/persistentstream/runtime/PersistentStreamEventProcessingConfigurer.java
@@ -1,7 +1,10 @@
 package at.meks.quarkiverse.axon.eventprocessor.persistentstream.runtime;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -12,6 +15,7 @@ import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.SubscribableMessageSource;
 
+import at.meks.quarkiverse.axon.runtime.conf.AxonConfiguration;
 import at.meks.quarkiverse.axon.runtime.customizations.AxonEventProcessingConfigurer;
 import io.axoniq.axonserver.connector.event.PersistentStreamProperties;
 
@@ -23,27 +27,47 @@ public class PersistentStreamEventProcessingConfigurer implements AxonEventProce
 
     @Inject
     ScheduledExecutorService executorService;
+    @Inject
+    AxonConfiguration axonConfiguration;
 
     @Override
-    public void configure(EventProcessingConfigurer configurer) {
+    public void configure(EventProcessingConfigurer configurer, Collection<Object> eventhandlers) {
         configurer.usingSubscribingEventProcessors();
-        configurer
-                .configureDefaultSubscribableMessageSource(this::defaultPersistentStreamMessageSource);
-        // for later: custom processor per handler group
-        //            eventProcessingConfigurer.registerSubscribingEventProcessor(${handler group name},
-        //                    conf -> new PersistentStreamMessageSource("eventstore", conf,
-        //                            streamProperties, executorService, persistentStreamConf.batchSize()));
+        // because of an unexptected behaviour in the axon framework, it's not possible to simply use a default
+        // message source. If so, only the eventhandlers of one package are informed about events.
+        // Maybe with the Axon framework version 4.11 this will be fixed in the framework.
+        //        configurer
+        //                .configureDefaultSubscribableMessageSource(this::defaultPersistentStreamMessageSource);
+        packagesOfEventhandlers(eventhandlers)
+                .forEach(pkgName -> configurer.registerSubscribingEventProcessor(pkgName,
+                        conf -> createPersistentStreamMessageSource(
+                                pkgName, conf,
+                                persistentStreamProperties(axonConfiguration.axonApplicationName() + "-" + pkgName))));
+    }
+
+    private PersistentStreamMessageSource createPersistentStreamMessageSource(String pkgName, Configuration conf,
+            PersistentStreamProperties persistentStreamProperties) {
+        return new PersistentStreamMessageSource(pkgName, conf, persistentStreamProperties, executorService,
+                persistentStreamProcessorConf.batchSize(), persistentStreamProcessorConf.context());
+    }
+
+    private Set<String> packagesOfEventhandlers(Collection<Object> eventhandlers) {
+        return eventhandlers.stream()
+                .map(Object::getClass)
+                .map(Class::getPackageName)
+                .collect(Collectors.toSet());
     }
 
     private SubscribableMessageSource<EventMessage<?>> defaultPersistentStreamMessageSource(Configuration conf) {
-        PersistentStreamProperties streamProperties = persistentStreamProperties();
-        return new PersistentStreamMessageSource(persistentStreamProcessorConf.messageSourceName(), conf, streamProperties,
-                executorService, persistentStreamProcessorConf.batchSize(), persistentStreamProcessorConf.context());
+        PersistentStreamProperties streamProperties = persistentStreamProperties(
+                persistentStreamProcessorConf.streamname());
+        return createPersistentStreamMessageSource(persistentStreamProcessorConf.messageSourceName(), conf,
+                streamProperties);
     }
 
-    private PersistentStreamProperties persistentStreamProperties() {
+    private PersistentStreamProperties persistentStreamProperties(String streamname) {
         return new PersistentStreamProperties(
-                persistentStreamProcessorConf.streamname(),
+                streamname,
                 persistentStreamProcessorConf.segments(),
                 SequencingPolicy.PER_AGGREGATE.axonName(),
                 Collections.emptyList(),

--- a/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledEventProcessingConfigurer.java
+++ b/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledEventProcessingConfigurer.java
@@ -1,5 +1,6 @@
 package at.meks.quarkiverse.axon.eventprocessor.pooled.runtime;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -18,7 +19,7 @@ public class PooledEventProcessingConfigurer implements AxonEventProcessingConfi
     PooledProcessorConf pooledProcessorConf;
 
     @Override
-    public void configure(EventProcessingConfigurer configurer) {
+    public void configure(EventProcessingConfigurer configurer, Collection<Object> eventhandlers) {
         EventProcessingConfigurer.PooledStreamingProcessorConfiguration psepConfig = (config, builder) -> {
             builder
                     .name(pooledProcessorConf.name())

--- a/eventprocessors/tracking/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/tracking/runtime/TrackingEventProcessingConfigurer.java
+++ b/eventprocessors/tracking/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/tracking/runtime/TrackingEventProcessingConfigurer.java
@@ -2,6 +2,7 @@ package at.meks.quarkiverse.axon.eventprocessor.tracking.runtime;
 
 import static at.meks.validation.args.ArgValidator.validate;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,7 +21,7 @@ public class TrackingEventProcessingConfigurer implements AxonEventProcessingCon
     TrackingProcessorConf trackingProcessorConf;
 
     @Override
-    public void configure(EventProcessingConfigurer configurer) {
+    public void configure(EventProcessingConfigurer configurer, Collection<Object> eventhandlers) {
         int threadCount = trackingProcessorConf.threadCount();
         validate().that(threadCount).isGreater(0);
         var trackingEventProcessorConfiguration = TrackingEventProcessorConfiguration

--- a/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardInMemoryHistory.java
+++ b/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardInMemoryHistory.java
@@ -14,10 +14,12 @@ import io.quarkus.logging.Log;
 public class GiftcardInMemoryHistory {
 
     private final List<Object> history = new ArrayList<>();
+    private boolean cardIssuedEventWasHandled = false;
 
     @EventHandler
     void handle(Api.CardIssuedEvent event) {
         Log.debugf("handling event %s", event);
+        cardIssuedEventWasHandled = true;
         history.add(event);
     }
 
@@ -31,4 +33,7 @@ public class GiftcardInMemoryHistory {
         return history.contains(event);
     }
 
+    public boolean cardIssuedEventWasHandled() {
+        return cardIssuedEventWasHandled;
+    }
 }

--- a/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardQueryHandler.java
+++ b/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardQueryHandler.java
@@ -15,6 +15,8 @@ public class GiftcardQueryHandler {
 
     private final Map<String, GiftcardView> giftcards = new HashMap<>();
 
+    private boolean cardIssuedEventWasHandled = false;
+
     @QueryHandler
     GiftcardView handle(Api.GiftcardQuery query) {
         return giftcards.get(query.id());
@@ -22,6 +24,7 @@ public class GiftcardQueryHandler {
 
     @EventHandler
     void handle(Api.CardIssuedEvent event) {
+        cardIssuedEventWasHandled = true;
         giftcards.put(event.id(), new GiftcardView(event.id(), event.amount()));
     }
 
@@ -33,5 +36,9 @@ public class GiftcardQueryHandler {
     @EventHandler
     void handle(Api.LatestRedemptionUndoneEvent event) {
         giftcards.get(event.id()).undoLastRedemption(event.amount());
+    }
+
+    public boolean cardIssuedEventWasHandled() {
+        return cardIssuedEventWasHandled;
     }
 }

--- a/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/projection2/AnotherProjection.java
+++ b/shared/model/src/main/java/at/meks/quarkiverse/axon/shared/projection2/AnotherProjection.java
@@ -1,0 +1,23 @@
+package at.meks.quarkiverse.axon.shared.projection2;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.eventhandling.EventHandler;
+
+import at.meks.quarkiverse.axon.shared.model.Api;
+
+@ApplicationScoped
+public class AnotherProjection {
+
+    private boolean cardIssuedEventWasHandled = false;
+
+    @EventHandler
+    void on(Api.CardIssuedEvent event) {
+        cardIssuedEventWasHandled = true;
+    }
+
+    public boolean cardIssuedEventWasHandled() {
+        return cardIssuedEventWasHandled;
+    }
+
+}

--- a/shared/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
+++ b/shared/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
@@ -28,6 +28,7 @@ import at.meks.quarkiverse.axon.shared.model.Giftcard;
 import at.meks.quarkiverse.axon.shared.projection.GiftcardInMemoryHistory;
 import at.meks.quarkiverse.axon.shared.projection.GiftcardQueryHandler;
 import at.meks.quarkiverse.axon.shared.projection.GiftcardView;
+import at.meks.quarkiverse.axon.shared.projection2.AnotherProjection;
 import io.quarkus.logging.Log;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -61,6 +62,10 @@ public class JavaArchiveTest {
     QueryGateway queryGateway;
     @Inject
     GiftcardInMemoryHistory giftcardInMemoryHistory;
+    @Inject
+    GiftcardQueryHandler giftcardQueryHandler;
+    @Inject
+    AnotherProjection anotherProjection;
 
     @Inject
     Configuration configuration;
@@ -95,12 +100,20 @@ public class JavaArchiveTest {
                 .usingRecursiveComparison()
                 .isEqualTo(new GiftcardView(cardId, 9));
 
+        assertThatAllEventHandlerClassesWereInformed();
+
         Optional<EventProcessor> eventProcessorOptional = configuration.eventProcessingConfiguration().eventProcessor(
                 "at.meks.quarkiverse.axon.shared.projection");
         assertThat(eventProcessorOptional).isPresent();
         assertConfiguration(configuration);
         assertConfiguration(eventProcessorOptional.get());
         assertOthers();
+    }
+
+    private void assertThatAllEventHandlerClassesWereInformed() {
+        assertTrue(giftcardQueryHandler.cardIssuedEventWasHandled(), "GiftcardQueryHandler was not informed");
+        assertTrue(giftcardInMemoryHistory.cardIssuedEventWasHandled(), "GiftcardInMemoryHistory was not informed");
+        assertTrue(anotherProjection.cardIssuedEventWasHandled(), "AnotherProjection was not informed");
     }
 
     protected void assertConfiguration(EventProcessor eventProcessor) {


### PR DESCRIPTION
The following fixes have been implemented:

* if event handlers are in different packages, only event handlers of one package have been informed
* if different applications use the same persistent stream name this could lead to strange behavior 