### PR TITLE
#118 Interface are now also injectable to message handlers

### DIFF
--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
@@ -52,11 +52,17 @@ public class InjectableCdiBeansTest {
     }
 
     @ApplicationScoped
-    static class InjectableCdiBeanForDomainService {
+    static class InjectableCdiBeanForDomainServiceImpl implements InjectableCdiBeanForDomainService {
 
-        void doSomething() {
+        public void doSomething() {
             logger.debug("do something");
         }
+
+    }
+
+    interface InjectableCdiBeanForDomainService {
+
+        void doSomething();
     }
 
     @ApplicationScoped


### PR DESCRIPTION
Because injectable beans were filtered for the annotation ApplicationScoped(what makes sense to exclude e.g. events from being injected by cdi), interfaces were also excluded.