### PR TITLE
Add support for Axon Server authentication token

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
@@ -75,5 +75,22 @@ endif::add-copy-button-to-env-var[]
 |string
 |`default`
 
+a| [[quarkus-axon-server_quarkus-axon-server-token]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token[`quarkus.axon.server.token`]##
+
+[.description]
+--
+The token used by the Axon Framework to connect to the Axon Server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_SERVER_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_SERVER_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
@@ -75,5 +75,22 @@ endif::add-copy-button-to-env-var[]
 |string
 |`default`
 
+a| [[quarkus-axon-server_quarkus-axon-server-token]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token[`quarkus.axon.server.token`]##
+
+[.description]
+--
+The token used by the Axon Framework to connect to the Axon Server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_SERVER_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_SERVER_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 |===
 

--- a/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/AxonServerConfigurer.java
+++ b/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/AxonServerConfigurer.java
@@ -34,10 +34,11 @@ public class AxonServerConfigurer implements EventstoreConfigurer {
     }
 
     private org.axonframework.axonserver.connector.AxonServerConfiguration axonServerConfiguration() {
-        return AxonServerConfiguration.builder()
+        AxonServerConfiguration.Builder builder = AxonServerConfiguration.builder()
                 .servers(serverConfiguration.hostname() + ":" + serverConfiguration.grpcPort())
-                .componentName(axonConfiguration.axonApplicationName())
-                .build();
+                .componentName(axonConfiguration.axonApplicationName());
+        serverConfiguration.token().ifPresent(builder::token);
+        return builder.build();
     }
 
     private EventStore axonserverEventStore(Configuration conf) {

--- a/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/QuarkusAxonServerConfiguration.java
+++ b/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/QuarkusAxonServerConfiguration.java
@@ -1,5 +1,7 @@
 package at.meks.quarkiverse.axon.server.runtime;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -27,4 +29,8 @@ public interface QuarkusAxonServerConfiguration {
     @WithDefault("default")
     String context();
 
+    /**
+     * The token used by the Axon Framework to connect to the Axon Server.
+     */
+    Optional<String> token();
 }

--- a/integration-tests/src/test/java/at/meks/quarkiverse/axon/it/ApplicationTest.java
+++ b/integration-tests/src/test/java/at/meks/quarkiverse/axon/it/ApplicationTest.java
@@ -52,8 +52,11 @@ class ApplicationTest {
         assertThatException().isThrownBy(() -> undoLatestRedemption(2))
                 .withMessageContaining("amount must be the lastest redeem amount")
                 .withMessageContaining("UndoLatestRedemptionCommand");
-
-        assertCurrentAmount(14);
+        Awaitility.await()
+                .pollDelay(Duration.ofMillis(30))
+                .pollInterval(Duration.ofMillis(100))
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertCurrentAmount(14));
         assertAtLeastOneSnaptshotExists();
     }
 


### PR DESCRIPTION
Introduced an optional `token` configuration property for Axon Server to enable authentication using a token.

This was a quick fix with a manual test. Automatic tests will follow later