### PR TITLE
Implement token-required configuration for Axon Server

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
@@ -92,5 +92,22 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-axon-server_quarkus-axon-server-token-required]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token-required[`quarkus.axon.server.token-required`]##
+
+[.description]
+--
+Indicates whether a token is required for connecting to the Axon Server. If it is required and not set, the startup will fail.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_SERVER_TOKEN_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_SERVER_TOKEN_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
@@ -92,5 +92,22 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-axon-server_quarkus-axon-server-token-required]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token-required[`quarkus.axon.server.token-required`]##
+
+[.description]
+--
+Indicates whether a token is required for connecting to the Axon Server. If it is required and not set, the startup will fail.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_SERVER_TOKEN_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_SERVER_TOKEN_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 |===
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -348,6 +348,10 @@ quarkus.axon.server.grpc-port=8124
 
 All you have to do is to define the correct host name, port and context if they don't match the default value.
 
+===== Security
+
+If you want to force, that the API Token is set, you can set the property `quarkus.axon.server.token-required` to true. If the token is required, but not set, a startup failure happens.
+
 ==== JPA Event Store
 
 Add the dependency

--- a/eventstores/axon-server/deployment/src/test/java/at/meks/quarkiverse/axon/server/deployment/TokenIsRequiredTest.java
+++ b/eventstores/axon-server/deployment/src/test/java/at/meks/quarkiverse/axon/server/deployment/TokenIsRequiredTest.java
@@ -1,0 +1,15 @@
+package at.meks.quarkiverse.axon.server.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TokenIsRequiredTest extends JavaArchiveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = application(javaArchiveBase()
+            .addAsResource(propertiesFile("/token-required.properties"), "application.properties"))
+            .setExpectedException(IllegalStateException.class, true);
+
+}

--- a/eventstores/axon-server/deployment/src/test/resources/token-required.properties
+++ b/eventstores/axon-server/deployment/src/test/resources/token-required.properties
@@ -1,0 +1,1 @@
+quarkus.axon.server.token-required=true

--- a/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/AxonServerConfigurer.java
+++ b/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/AxonServerConfigurer.java
@@ -37,6 +37,9 @@ public class AxonServerConfigurer implements EventstoreConfigurer {
         AxonServerConfiguration.Builder builder = AxonServerConfiguration.builder()
                 .servers(serverConfiguration.hostname() + ":" + serverConfiguration.grpcPort())
                 .componentName(axonConfiguration.axonApplicationName());
+        if (serverConfiguration.tokenRequired() && serverConfiguration.token().isEmpty()) {
+            throw new IllegalStateException("Axon server token is required but not configured");
+        }
         serverConfiguration.token().ifPresent(builder::token);
         return builder.build();
     }

--- a/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/QuarkusAxonServerConfiguration.java
+++ b/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/QuarkusAxonServerConfiguration.java
@@ -33,4 +33,11 @@ public interface QuarkusAxonServerConfiguration {
      * The token used by the Axon Framework to connect to the Axon Server.
      */
     Optional<String> token();
+
+    /**
+     * Indicates whether a token is required for connecting to the Axon Server.
+     * If it is required and not set, the startup will fail.
+     */
+    @WithDefault("false")
+    boolean tokenRequired();
 }


### PR DESCRIPTION
Added configuration property `quarkus.axon.server.token-required` to enforce token requirements for Axon Server connections. If enabled and no token is provided, an `IllegalStateException` is thrown at startup.