### PR TITLE
#48 enabled custom JacksonSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ There are different saga stores you can use
   * EventHandler
   * QueryHandler
 * Upcasters
+* custom Jackson Serialization
+* Information provided to Dev-UI
 
 
 #### Live reloading

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/serializer/CustomSerializerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/serializer/CustomSerializerTest.java
@@ -1,0 +1,19 @@
+package at.meks.quarkiverse.axon.deployment.serializer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CustomSerializerTest extends JavaArchiveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = application(javaArchiveBase()
+            .addClasses(MyCustomJacksonSerializerProducer.class));
+
+    @Override
+    protected void assertOthers() {
+        Assertions.assertTrue(MyCustomJacksonSerializerProducer.isCustomSerializerUsed());
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/serializer/MyCustomJacksonSerializerProducer.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/serializer/MyCustomJacksonSerializerProducer.java
@@ -1,0 +1,37 @@
+package at.meks.quarkiverse.axon.deployment.serializer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.serialization.json.JacksonSerializer;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import at.meks.quarkiverse.axon.runtime.customizations.JacksonSerializerProducer;
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class MyCustomJacksonSerializerProducer implements JacksonSerializerProducer {
+
+    public static JacksonSerializer INSTANCE = JacksonSerializer.builder().objectMapper(createObjectMapper()).build();
+    private static boolean customSerializerUsed;
+
+    @Override
+    public JacksonSerializer createSerializer() {
+        Log.info("My custom Jackson serializer producer is used.");
+        customSerializerUsed = true;
+        return INSTANCE;
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+        objectMapper.getVisibilityChecker().withFieldVisibility(JsonAutoDetect.Visibility.ANY);
+        return objectMapper;
+    }
+
+    public static boolean isCustomSerializerUsed() {
+        return customSerializerUsed;
+    }
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/JacksonSerializerProducer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/JacksonSerializerProducer.java
@@ -1,0 +1,9 @@
+package at.meks.quarkiverse.axon.runtime.customizations;
+
+import org.axonframework.serialization.json.JacksonSerializer;
+
+public interface JacksonSerializerProducer {
+
+    JacksonSerializer createSerializer();
+
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
@@ -16,8 +16,6 @@ import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import at.meks.quarkiverse.axon.runtime.customizations.*;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.logging.Log;
@@ -25,9 +23,6 @@ import io.quarkus.logging.Log;
 @Dependent
 @DefaultBean
 class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
-
-    @Inject
-    ObjectMapper objectMapper;
 
     @Inject
     TransactionManager transactionManager;
@@ -56,6 +51,9 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
     @Inject
     SagaStoreConfigurer sagaStoreConfigurer;
 
+    @Inject
+    JacksonSerializerProducer jacksonSerializerProducer;
+
     private Set<Class<?>> aggregateClasses;
     private Set<Object> eventhandlers;
     private Set<Object> commandhandlers;
@@ -67,10 +65,10 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
     public Configurer configure() {
         final Configurer configurer;
         Log.debug("creating the axon configuration");
-        JacksonSerializer jacksonSerializer = JacksonSerializer.builder().objectMapper(objectMapper).build();
+        JacksonSerializer jacksonSerializer = jacksonSerializerProducer.createSerializer();
         configurer = DefaultConfigurer.defaultConfiguration()
                 .configureSerializer(conf -> jacksonSerializer)
-                .configureEventSerializer(confg -> jacksonSerializer);
+                .configureEventSerializer(config -> jacksonSerializer);
 
         eventstoreConfigurer.configure(configurer);
         configureAggregates(configurer);

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/QuarkusJacksonSerializerProducer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/QuarkusJacksonSerializerProducer.java
@@ -1,0 +1,27 @@
+package at.meks.quarkiverse.axon.runtime.defaults;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.axonframework.serialization.json.JacksonSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import at.meks.quarkiverse.axon.runtime.customizations.JacksonSerializerProducer;
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.logging.Log;
+
+@DefaultBean
+@ApplicationScoped
+public class QuarkusJacksonSerializerProducer implements JacksonSerializerProducer {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Override
+    public JacksonSerializer createSerializer() {
+        Log.info("Quarkus objectMapper is used for serialization");
+        return JacksonSerializer.builder().objectMapper(objectMapper).build();
+    }
+
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-jdbc-eventstore.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-jdbc-eventstore.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-batch-size]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-batch-size[`quarkus.axon.eventstore.jdbc.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -27,6 +31,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-cleaning-threshold]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-cleaning-threshold[`quarkus.axon.eventstore.jdbc.gap-cleaning-threshold`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.gap-cleaning-threshold+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -46,6 +54,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-lowest-global-sequence]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-lowest-global-sequence[`quarkus.axon.eventstore.jdbc.lowest-global-sequence`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.lowest-global-sequence+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -65,6 +77,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-timeout]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-timeout[`quarkus.axon.eventstore.jdbc.gap-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.gap-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -84,6 +100,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-max-gap-offset]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-max-gap-offset[`quarkus.axon.eventstore.jdbc.max-gap-offset`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.max-gap-offset+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -103,6 +123,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-extended-gap-check-enabled]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-extended-gap-check-enabled[`quarkus.axon.eventstore.jdbc.extended-gap-check-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.extended-gap-check-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -120,6 +144,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-autocreate-tables]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-autocreate-tables[`quarkus.axon.eventstore.jdbc.autocreate-tables`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.autocreate-tables+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -137,6 +165,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-event-table-name]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-event-table-name[`quarkus.axon.eventstore.jdbc.event-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.event-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -154,6 +186,10 @@ endif::add-copy-button-to-env-var[]
 |`DomainEventEntry`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-snapshot-table-name]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-snapshot-table-name[`quarkus.axon.eventstore.jdbc.snapshot-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.snapshot-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-jdbc-eventstore_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-jdbc-eventstore_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-batch-size]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-batch-size[`quarkus.axon.eventstore.jdbc.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -27,6 +31,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-cleaning-threshold]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-cleaning-threshold[`quarkus.axon.eventstore.jdbc.gap-cleaning-threshold`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.gap-cleaning-threshold+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -46,6 +54,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-lowest-global-sequence]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-lowest-global-sequence[`quarkus.axon.eventstore.jdbc.lowest-global-sequence`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.lowest-global-sequence+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -65,6 +77,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-timeout]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-gap-timeout[`quarkus.axon.eventstore.jdbc.gap-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.gap-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -84,6 +100,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-max-gap-offset]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-max-gap-offset[`quarkus.axon.eventstore.jdbc.max-gap-offset`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.max-gap-offset+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -103,6 +123,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-extended-gap-check-enabled]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-extended-gap-check-enabled[`quarkus.axon.eventstore.jdbc.extended-gap-check-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.extended-gap-check-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -120,6 +144,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-autocreate-tables]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-autocreate-tables[`quarkus.axon.eventstore.jdbc.autocreate-tables`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.autocreate-tables+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -137,6 +165,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-event-table-name]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-event-table-name[`quarkus.axon.eventstore.jdbc.event-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.event-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -154,6 +186,10 @@ endif::add-copy-button-to-env-var[]
 |`DomainEventEntry`
 
 a| [[quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-snapshot-table-name]] [.property-path]##link:#quarkus-axon-jdbc-eventstore_quarkus-axon-eventstore-jdbc-snapshot-table-name[`quarkus.axon.eventstore.jdbc.snapshot-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jdbc.snapshot-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-jpa-eventstore.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-jpa-eventstore.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-batch-size]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-batch-size[`quarkus.axon.eventstore.jpa.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -27,6 +31,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-explicit-flush]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-explicit-flush[`quarkus.axon.eventstore.jpa.explicit-flush`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.explicit-flush+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -44,6 +52,10 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-cleaning-threshold]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-cleaning-threshold[`quarkus.axon.eventstore.jpa.gap-cleaning-threshold`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.gap-cleaning-threshold+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -63,6 +75,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-lowest-global-sequence]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-lowest-global-sequence[`quarkus.axon.eventstore.jpa.lowest-global-sequence`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.lowest-global-sequence+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -82,6 +98,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-timeout]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-timeout[`quarkus.axon.eventstore.jpa.gap-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.gap-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -101,6 +121,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-max-gap-offset]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-max-gap-offset[`quarkus.axon.eventstore.jpa.max-gap-offset`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.max-gap-offset+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-jpa-eventstore_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-jpa-eventstore_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-batch-size]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-batch-size[`quarkus.axon.eventstore.jpa.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -27,6 +31,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-explicit-flush]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-explicit-flush[`quarkus.axon.eventstore.jpa.explicit-flush`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.explicit-flush+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -44,6 +52,10 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-cleaning-threshold]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-cleaning-threshold[`quarkus.axon.eventstore.jpa.gap-cleaning-threshold`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.gap-cleaning-threshold+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -63,6 +75,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-lowest-global-sequence]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-lowest-global-sequence[`quarkus.axon.eventstore.jpa.lowest-global-sequence`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.lowest-global-sequence+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -82,6 +98,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-timeout]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-gap-timeout[`quarkus.axon.eventstore.jpa.gap-timeout`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.gap-timeout+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -101,6 +121,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-max-gap-offset]] [.property-path]##link:#quarkus-axon-jpa-eventstore_quarkus-axon-eventstore-jpa-max-gap-offset[`quarkus.axon.eventstore.jpa.max-gap-offset`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.eventstore.jpa.max-gap-offset+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-metrics.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-metrics.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-metrics_quarkus-axon-metrics-enabled]] [.property-path]##link:#quarkus-axon-metrics_quarkus-axon-metrics-enabled[`quarkus.axon.metrics.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.metrics.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-metrics_quarkus-axon-metrics-with-tags]] [.property-path]##link:#quarkus-axon-metrics_quarkus-axon-metrics-with-tags[`quarkus.axon.metrics.with-tags`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.metrics.with-tags+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-metrics_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-metrics_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-metrics_quarkus-axon-metrics-enabled]] [.property-path]##link:#quarkus-axon-metrics_quarkus-axon-metrics-enabled[`quarkus.axon.metrics.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.metrics.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-metrics_quarkus-axon-metrics-with-tags]] [.property-path]##link:#quarkus-axon-metrics_quarkus-axon-metrics-with-tags[`quarkus.axon.metrics.with-tags`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.metrics.with-tags+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-batch-size]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-batch-size[`quarkus.axon.persistentstreams.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments[`quarkus.axon.persistentstreams.initial-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.initial-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-context]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-context[`quarkus.axon.persistentstreams.context`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.context+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ endif::add-copy-button-to-env-var[]
 |`default`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-segments]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-segments[`quarkus.axon.persistentstreams.segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`4`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-position]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-position[`quarkus.axon.persistentstreams.initial-position`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.initial-position+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-filter]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-filter[`quarkus.axon.persistentstreams.filter`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.filter+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-persistent-stream-eventprocessor_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-batch-size]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-batch-size[`quarkus.axon.persistentstreams.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-segments[`quarkus.axon.persistentstreams.initial-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.initial-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-context]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-context[`quarkus.axon.persistentstreams.context`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.context+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ endif::add-copy-button-to-env-var[]
 |`default`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-segments]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-segments[`quarkus.axon.persistentstreams.segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`4`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-position]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-initial-position[`quarkus.axon.persistentstreams.initial-position`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.initial-position+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 a| [[quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-filter]] [.property-path]##link:#quarkus-axon-persistent-stream-eventprocessor_quarkus-axon-persistentstreams-filter[`quarkus.axon.persistentstreams.filter`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.persistentstreams.filter+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-batch-size]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-batch-size[`quarkus.axon.pooledprocessor.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-segments]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-segments[`quarkus.axon.pooledprocessor.initial-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.initial-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-position]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-position[`quarkus.axon.pooledprocessor.initial-position`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.initial-position+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ a|`head`, `tail`
 |`tail`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-max-claimed-segments]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-max-claimed-segments[`quarkus.axon.pooledprocessor.max-claimed-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.max-claimed-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-enabled-coordinator-claim-extension]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-enabled-coordinator-claim-extension[`quarkus.axon.pooledprocessor.enabled-coordinator-claim-extension`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.enabled-coordinator-claim-extension+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name[`quarkus.axon.pooledprocessor.name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-batch-size]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-batch-size[`quarkus.axon.pooledprocessor.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-segments]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-segments[`quarkus.axon.pooledprocessor.initial-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.initial-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-position]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-initial-position[`quarkus.axon.pooledprocessor.initial-position`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.initial-position+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ a|`head`, `tail`
 |`tail`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-max-claimed-segments]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-max-claimed-segments[`quarkus.axon.pooledprocessor.max-claimed-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.max-claimed-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-enabled-coordinator-claim-extension]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-enabled-coordinator-claim-extension[`quarkus.axon.pooledprocessor.enabled-coordinator-claim-extension`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.enabled-coordinator-claim-extension+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name[`quarkus.axon.pooledprocessor.name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-sagastore-jdbc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-sagastore-jdbc.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-autocreate-table]] [.property-path]##link:#quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-autocreate-table[`quarkus.axon.sagastore.jdbc.autocreate-table`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.sagastore.jdbc.autocreate-table+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-saga-table-name]] [.property-path]##link:#quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-saga-table-name[`quarkus.axon.sagastore.jdbc.saga-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.sagastore.jdbc.saga-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-association-value-table-name]] [.property-path]##link:#quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-association-value-table-name[`quarkus.axon.sagastore.jdbc.association-value-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.sagastore.jdbc.association-value-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-sagastore-jdbc_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-sagastore-jdbc_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-autocreate-table]] [.property-path]##link:#quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-autocreate-table[`quarkus.axon.sagastore.jdbc.autocreate-table`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.sagastore.jdbc.autocreate-table+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-saga-table-name]] [.property-path]##link:#quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-saga-table-name[`quarkus.axon.sagastore.jdbc.saga-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.sagastore.jdbc.saga-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-association-value-table-name]] [.property-path]##link:#quarkus-axon-sagastore-jdbc_quarkus-axon-sagastore-jdbc-association-value-table-name[`quarkus.axon.sagastore.jdbc.association-value-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.sagastore.jdbc.association-value-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a|icon:lock[title=Fixed at build time] [[quarkus-axon-server_quarkus-axon-server-health-enabled]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-health-enabled[`quarkus.axon.server.health-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.health-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-server_quarkus-axon-server-hostname]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-hostname[`quarkus.axon.server.hostname`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.hostname+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`localhost`
 
 a| [[quarkus-axon-server_quarkus-axon-server-grpc-port]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-grpc-port[`quarkus.axon.server.grpc-port`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.grpc-port+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ endif::add-copy-button-to-env-var[]
 |`8124`
 
 a| [[quarkus-axon-server_quarkus-axon-server-context]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-context[`quarkus.axon.server.context`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.context+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`default`
 
 a| [[quarkus-axon-server_quarkus-axon-server-token]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token[`quarkus.axon.server.token`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.token+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-axon-server_quarkus-axon-server-token-required]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token-required[`quarkus.axon.server.token-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.token-required+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a|icon:lock[title=Fixed at build time] [[quarkus-axon-server_quarkus-axon-server-health-enabled]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-health-enabled[`quarkus.axon.server.health-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.health-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-server_quarkus-axon-server-hostname]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-hostname[`quarkus.axon.server.hostname`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.hostname+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`localhost`
 
 a| [[quarkus-axon-server_quarkus-axon-server-grpc-port]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-grpc-port[`quarkus.axon.server.grpc-port`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.grpc-port+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ endif::add-copy-button-to-env-var[]
 |`8124`
 
 a| [[quarkus-axon-server_quarkus-axon-server-context]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-context[`quarkus.axon.server.context`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.context+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`default`
 
 a| [[quarkus-axon-server_quarkus-axon-server-token]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token[`quarkus.axon.server.token`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.token+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-axon-server_quarkus-axon-server-token-required]] [.property-path]##link:#quarkus-axon-server_quarkus-axon-server-token-required[`quarkus.axon.server.token-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.server.token-required+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jdbc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jdbc.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-autocreate-table-for-jdbc-token]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-autocreate-table-for-jdbc-token[`quarkus.axon.tokenstore.jdbc.autocreate-table-for-jdbc-token`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.autocreate-table-for-jdbc-token+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-unit]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-unit[`quarkus.axon.tokenstore.jdbc.claim-timeout.unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.claim-timeout.unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ a|`nanoseconds`, `microseconds`, `milliseconds`, `seconds`, `minutes`, `hours`, 
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-amount]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-amount[`quarkus.axon.tokenstore.jdbc.claim-timeout.amount`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.claim-timeout.amount+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ endif::add-copy-button-to-env-var[]
 |`0l`
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-token-table-name]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-token-table-name[`quarkus.axon.tokenstore.jdbc.token-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.token-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jdbc_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jdbc_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-autocreate-table-for-jdbc-token]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-autocreate-table-for-jdbc-token[`quarkus.axon.tokenstore.jdbc.autocreate-table-for-jdbc-token`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.autocreate-table-for-jdbc-token+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-unit]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-unit[`quarkus.axon.tokenstore.jdbc.claim-timeout.unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.claim-timeout.unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ a|`nanoseconds`, `microseconds`, `milliseconds`, `seconds`, `minutes`, `hours`, 
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-amount]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-claim-timeout-amount[`quarkus.axon.tokenstore.jdbc.claim-timeout.amount`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.claim-timeout.amount+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ endif::add-copy-button-to-env-var[]
 |`0l`
 
 a| [[quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-token-table-name]] [.property-path]##link:#quarkus-axon-tokenstore-jdbc_quarkus-axon-tokenstore-jdbc-token-table-name[`quarkus.axon.tokenstore.jdbc.token-table-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jdbc.token-table-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jpa.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jpa.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-unit]] [.property-path]##link:#quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-unit[`quarkus.axon.tokenstore.jpa.claim-timeout.unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jpa.claim-timeout.unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ a|`nanoseconds`, `microseconds`, `milliseconds`, `seconds`, `minutes`, `hours`, 
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-amount]] [.property-path]##link:#quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-amount[`quarkus.axon.tokenstore.jpa.claim-timeout.amount`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jpa.claim-timeout.amount+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`0l`
 
 a| [[quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-loading-lock-mode]] [.property-path]##link:#quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-loading-lock-mode[`quarkus.axon.tokenstore.jpa.loading-lock-mode`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jpa.loading-lock-mode+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jpa_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tokenstore-jpa_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-unit]] [.property-path]##link:#quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-unit[`quarkus.axon.tokenstore.jpa.claim-timeout.unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jpa.claim-timeout.unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ a|`nanoseconds`, `microseconds`, `milliseconds`, `seconds`, `minutes`, `hours`, 
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-amount]] [.property-path]##link:#quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-claim-timeout-amount[`quarkus.axon.tokenstore.jpa.claim-timeout.amount`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jpa.claim-timeout.amount+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`0l`
 
 a| [[quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-loading-lock-mode]] [.property-path]##link:#quarkus-axon-tokenstore-jpa_quarkus-axon-tokenstore-jpa-loading-lock-mode[`quarkus.axon.tokenstore.jpa.loading-lock-mode`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.tokenstore.jpa.loading-lock-mode+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-batch-size]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-batch-size[`quarkus.axon.trackingprocessor.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-segments]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-segments[`quarkus.axon.trackingprocessor.initial-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.initial-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-position]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-position[`quarkus.axon.trackingprocessor.initial-position`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.initial-position+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ a|`head`, `tail`
 |`tail`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-thread-count]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-thread-count[`quarkus.axon.trackingprocessor.thread-count`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.thread-count+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-interval]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-interval[`quarkus.axon.trackingprocessor.token-claim.interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.token-claim.interval+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-time-unit]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-time-unit[`quarkus.axon.trackingprocessor.token-claim.time-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.token-claim.time-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-tracking-eventprocessor_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-batch-size]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-batch-size[`quarkus.axon.trackingprocessor.batch-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-segments]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-segments[`quarkus.axon.trackingprocessor.initial-segments`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.initial-segments+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-position]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-initial-position[`quarkus.axon.trackingprocessor.initial-position`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.initial-position+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ a|`head`, `tail`
 |`tail`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-thread-count]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-thread-count[`quarkus.axon.trackingprocessor.thread-count`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.thread-count+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-interval]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-interval[`quarkus.axon.trackingprocessor.token-claim.interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.token-claim.interval+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-time-unit]] [.property-path]##link:#quarkus-axon-tracking-eventprocessor_quarkus-axon-trackingprocessor-token-claim-time-unit[`quarkus.axon.trackingprocessor.token-claim.time-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.trackingprocessor.token-claim.time-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a|icon:lock[title=Fixed at build time] [[quarkus-axon_quarkus-axon-health-enabled]] [.property-path]##link:#quarkus-axon_quarkus-axon-health-enabled[`quarkus.axon.health-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.health-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon_quarkus-axon-axon-application-name]] [.property-path]##link:#quarkus-axon_quarkus-axon-axon-application-name[`quarkus.axon.axon-application-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.axon-application-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`quarkus-axon`
 
 a| [[quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit]] [.property-path]##link:#quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit[`quarkus.axon.live-reload.shutdown.wait-duration.unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.live-reload.shutdown.wait-duration.unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ a|`nanoseconds`, `microseconds`, `milliseconds`, `seconds`, `minutes`, `hours`, 
 |`milliseconds`
 
 a| [[quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-amount]] [.property-path]##link:#quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-amount[`quarkus.axon.live-reload.shutdown.wait-duration.amount`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.live-reload.shutdown.wait-duration.amount+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`500`
 
 a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler[`quarkus.axon.exception-handling.wrap-on-command-handler`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.exception-handling.wrap-on-command-handler+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler[`quarkus.axon.exception-handling.wrap-on-query-handler`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.exception-handling.wrap-on-query-handler+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -110,8 +134,15 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots.trigger-type+++[]
+endif::add-copy-button-to-config-props[]
+
 
 `quarkus.axon.snapshots."aggregate-name".trigger-type`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots."aggregate-name".trigger-type+++[]
+endif::add-copy-button-to-config-props[]
 
 [.description]
 --
@@ -129,8 +160,15 @@ a|`no-snapshots`, `load-time`, `event-count`
 |`no-snapshots`
 
 a| [[quarkus-axon_quarkus-axon-snapshots-threshold]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-threshold[`quarkus.axon.snapshots.threshold`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots.threshold+++[]
+endif::add-copy-button-to-config-props[]
+
 
 `quarkus.axon.snapshots."aggregate-name".threshold`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots."aggregate-name".threshold+++[]
+endif::add-copy-button-to-config-props[]
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -8,6 +8,10 @@ h|Type
 h|Default
 
 a|icon:lock[title=Fixed at build time] [[quarkus-axon_quarkus-axon-health-enabled]] [.property-path]##link:#quarkus-axon_quarkus-axon-health-enabled[`quarkus.axon.health-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.health-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,6 +29,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon_quarkus-axon-axon-application-name]] [.property-path]##link:#quarkus-axon_quarkus-axon-axon-application-name[`quarkus.axon.axon-application-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.axon-application-name+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,6 +50,10 @@ endif::add-copy-button-to-env-var[]
 |`quarkus-axon`
 
 a| [[quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit]] [.property-path]##link:#quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit[`quarkus.axon.live-reload.shutdown.wait-duration.unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.live-reload.shutdown.wait-duration.unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,6 +71,10 @@ a|`nanoseconds`, `microseconds`, `milliseconds`, `seconds`, `minutes`, `hours`, 
 |`milliseconds`
 
 a| [[quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-amount]] [.property-path]##link:#quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-amount[`quarkus.axon.live-reload.shutdown.wait-duration.amount`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.live-reload.shutdown.wait-duration.amount+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,6 +92,10 @@ endif::add-copy-button-to-env-var[]
 |`500`
 
 a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-command-handler[`quarkus.axon.exception-handling.wrap-on-command-handler`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.exception-handling.wrap-on-command-handler+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -93,6 +113,10 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-wrap-on-query-handler[`quarkus.axon.exception-handling.wrap-on-query-handler`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.exception-handling.wrap-on-query-handler+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -110,8 +134,15 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots.trigger-type+++[]
+endif::add-copy-button-to-config-props[]
+
 
 `quarkus.axon.snapshots."aggregate-name".trigger-type`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots."aggregate-name".trigger-type+++[]
+endif::add-copy-button-to-config-props[]
 
 [.description]
 --
@@ -129,8 +160,15 @@ a|`no-snapshots`, `load-time`, `event-count`
 |`no-snapshots`
 
 a| [[quarkus-axon_quarkus-axon-snapshots-threshold]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-threshold[`quarkus.axon.snapshots.threshold`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots.threshold+++[]
+endif::add-copy-button-to-config-props[]
+
 
 `quarkus.axon.snapshots."aggregate-name".threshold`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.snapshots."aggregate-name".threshold+++[]
+endif::add-copy-button-to-config-props[]
 
 [.description]
 --

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -907,6 +907,14 @@ If you need to access the
 
 you can simply inject it to your CDI bean. The repository and the command gateway injection is shown in the example above.
 
+=== Serialization
+
+By default the Jackson Serializer of quarkus is used. It is the same, which is used for REST services.
+
+If you need to adapt the serializer, keep in mind, that also the serialization for the REST services is changed.
+
+If you want to configure only the serialization of Axon releated data, you can implement `JacksonSerializerProducer`.
+
 [[extension-configuration-reference]]
 == Extension Configuration Reference
 

--- a/eventstores/axon-server/deployment/src/main/java/at/meks/quarkiverse/axon/server/deployment/AxonServerProcessor.java
+++ b/eventstores/axon-server/deployment/src/main/java/at/meks/quarkiverse/axon/server/deployment/AxonServerProcessor.java
@@ -13,7 +13,7 @@ import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.logging.Log;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
@@ -33,7 +33,7 @@ public class AxonServerProcessor {
                 .build();
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     public DevServicesResultBuildItem createContainer() {
         DockerImageName dockerImageName = DockerImageName.parse("axoniq/axonserver");
         GenericContainer<?> container = new GenericContainer<>(dockerImageName)


### PR DESCRIPTION
Replaced direct `ObjectMapper` injection with a dedicated `JacksonSerializerProducer` for improved modularity and clarity.

The quarkus-axon-*.adoc documents changed, because of the quarkus upgrade.