### PR TITLE
#133: Pool Eventprocessor can be paused and started using Axon Server

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
@@ -112,26 +112,5 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name[`quarkus.axon.pooledprocessor.name`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.axon.pooledprocessor.name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Sets the name of the event processor.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_AXON_POOLEDPROCESSOR_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`quarkus-pooled-processor`
-
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
@@ -112,26 +112,5 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
-a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-name[`quarkus.axon.pooledprocessor.name`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.axon.pooledprocessor.name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Sets the name of the event processor.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_AXON_POOLEDPROCESSOR_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`quarkus-pooled-processor`
-
 |===
 

--- a/eventprocessors/pooled/deployment/src/test/java/at/meks/quarkiverse/axon/eventprocessor/pooled/deployment/AllPropertiesChangedTest.java
+++ b/eventprocessors/pooled/deployment/src/test/java/at/meks/quarkiverse/axon/eventprocessor/pooled/deployment/AllPropertiesChangedTest.java
@@ -17,6 +17,5 @@ public class AllPropertiesChangedTest extends PooledProcessorTest {
     protected void assertPooledConfiguration(PooledStreamingEventProcessor eventProcessor) {
         // Other changed properties can't be asserted because currently they can't be accessed.
         assertEquals(4, eventProcessor.maxCapacity());
-        assertEquals("myCustomName", eventProcessor.getName());
     }
 }

--- a/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledProcessorConf.java
+++ b/eventprocessors/pooled/runtime/src/main/java/at/meks/quarkiverse/axon/eventprocessor/pooled/runtime/PooledProcessorConf.java
@@ -26,12 +26,6 @@ public interface PooledProcessorConf extends StreamingProcessorConf {
     boolean enabledCoordinatorClaimExtension();
 
     /**
-     * Sets the name of the event processor.
-     */
-    @WithDefault("quarkus-pooled-processor")
-    String name();
-
-    /**
      * Set the maximum number of events that may be processed in a single transaction. If -1 is set, the default of the Axon
      * framework is used.
      */


### PR DESCRIPTION
Removed the possibility to set the name in the application.propterties and the name of the processors is not set anymore.