### PR TITLE
Support for RetryScheduler in CommandGateway

### DIFF
--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/CommandGatewayRetrySchedulerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/CommandGatewayRetrySchedulerTest.java
@@ -1,0 +1,49 @@
+package at.meks.quarkiverse.axon.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Produces;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.commandhandling.gateway.RetryScheduler;
+import org.axonframework.config.Configuration;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CommandGatewayRetrySchedulerTest extends JavaArchiveTest {
+
+    @Inject
+    RetryScheduler retryScheduler;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClasses(MyRetrySchedulerProducer.class));
+
+    public static class MyRetrySchedulerProducer {
+
+        @Produces
+        @ApplicationScoped
+        public RetryScheduler retryScheduler() {
+            return Mockito.mock(RetryScheduler.class);
+        }
+
+    }
+
+    @Override
+    protected void assertConfiguration(Configuration configuration) {
+        DefaultCommandGateway commandGateway = (DefaultCommandGateway) configuration.commandGateway();
+        try {
+            Object actualRetryScheduler = FieldUtils.readField(commandGateway, "retryScheduler", true);
+            assertThat(actualRetryScheduler).isSameAs(retryScheduler);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandgateway/BackoffRetrySchedulerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandgateway/BackoffRetrySchedulerTest.java
@@ -1,0 +1,15 @@
+package at.meks.quarkiverse.axon.deployment.commandgateway;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BackoffRetrySchedulerTest extends JavaArchiveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = application(javaArchiveBase()
+            .addAsResource(propertiesFile("/commandgateway/backoffretry.properties"),
+                    "application.properties"));
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandgateway/CustomRetrySchedulerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandgateway/CustomRetrySchedulerTest.java
@@ -1,4 +1,4 @@
-package at.meks.quarkiverse.axon.deployment;
+package at.meks.quarkiverse.axon.deployment.commandgateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,7 +16,7 @@ import org.mockito.Mockito;
 import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class CommandGatewayRetrySchedulerTest extends JavaArchiveTest {
+public class CustomRetrySchedulerTest extends JavaArchiveTest {
 
     @Inject
     RetryScheduler retryScheduler;

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandgateway/IntervalRetrySchedulerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandgateway/IntervalRetrySchedulerTest.java
@@ -1,0 +1,15 @@
+package at.meks.quarkiverse.axon.deployment.commandgateway;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class IntervalRetrySchedulerTest extends JavaArchiveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = application(javaArchiveBase()
+            .addAsResource(propertiesFile("/commandgateway/intervalretry.properties"),
+                    "application.properties"));
+
+}

--- a/core/deployment/src/test/resources/commandgateway/backoffretry.properties
+++ b/core/deployment/src/test/resources/commandgateway/backoffretry.properties
@@ -1,0 +1,2 @@
+quarkus.axon.command-gateway.retry.scheduling.backoff-factor=100
+quarkus.axon.command-gateway.retry.scheduling.max-retry-count=10

--- a/core/deployment/src/test/resources/commandgateway/intervalretry.properties
+++ b/core/deployment/src/test/resources/commandgateway/intervalretry.properties
@@ -1,0 +1,2 @@
+quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval=100
+quarkus.axon.command-gateway.retry.scheduling.max-retry-count=10

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -42,6 +42,16 @@
             <artifactId>args</artifactId>
             <version>2.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
@@ -1,6 +1,7 @@
 package at.meks.quarkiverse.axon.runtime.conf;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -39,6 +40,12 @@ public interface AxonConfiguration {
      * Configuration for Exception Handling in the Axon framework.
      */
     ExceptionHandlingConfig exceptionHandling();
+
+    /**
+     * Configure the retry scheduling for dispatching Command on the CommandGateway.
+     */
+    @WithName("command-gateway.retry.scheduling")
+    CommandRetryScheduling commandGatewayRetryScheduling();
 
     /**
      * Live reloading needs a wait time, to wait for axon's framework or axon's server to cleanup. This wait time seems
@@ -116,6 +123,31 @@ public interface AxonConfiguration {
          */
         @WithDefault("true")
         boolean wrapOnQueryHandler();
+    }
+
+    interface CommandRetryScheduling {
+
+        /**
+         * The fixed retry interval for retry scheduling(IntervalRetryScheduler), if configured. The fixed retry
+         * interval specifies a consistent delay duration between retries. If a fixed retry
+         * interval is configured, a maximum retry count must also be specified to ensure
+         * proper retry behavior.
+         */
+        Optional<Integer> fixedRetryInterval();
+
+        /**
+         * if you have configured either the {@link #fixedRetryInterval()} or the {@link #backoffFactor()} you must
+         * configure the maximum retries as well.
+         */
+        Optional<Integer> maxRetryCount();
+
+        /**
+         * backoff factor for retry scheduling(ExponentialBackOffIntervalRetryScheduler). This value is used in
+         * conjunction with an exponential backoff retry mechanism, where the interval
+         * between retries increases over time based on this factor. If configured, the
+         * maximum retries must also be set.
+         */
+        Optional<Integer> backoffFactor();
     }
 
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/RetrySchedulerConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/RetrySchedulerConfigurer.java
@@ -1,0 +1,123 @@
+package at.meks.quarkiverse.axon.runtime.defaults;
+
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.axonframework.commandhandling.gateway.ExponentialBackOffIntervalRetryScheduler;
+import org.axonframework.commandhandling.gateway.IntervalRetryScheduler;
+import org.axonframework.commandhandling.gateway.RetryScheduler;
+
+import at.meks.quarkiverse.axon.runtime.conf.AxonConfiguration;
+
+@ApplicationScoped
+class RetrySchedulerConfigurer {
+
+    @Inject
+    AxonConfiguration axonConfiguration;
+
+    @Inject
+    Instance<RetryScheduler> retrySchedulerProducer;
+
+    @Inject
+    ScheduledExecutorService executorService;
+
+    Optional<RetryScheduler> retryScheduler() {
+        validateRetryConfiguration();
+        if (intervalRetrySchedulerIsConfigured()) {
+            return Optional.of(intervalRetryScheduler());
+        } else if (exponentialBackoffIntervalRetrySchedulerIsConfigured()) {
+            return Optional.of(backoffIntervalRetryScheduler());
+        } else if (customRetrySchedulerIsProvided()) {
+            return Optional.of(customRetryScheduler());
+        }
+        return Optional.empty();
+    }
+
+    private void validateRetryConfiguration() {
+        if (isOnlyMaxRetryConfigured()) {
+            throw new IllegalStateException(
+                    "Retry Scheduler max retry count is configured but either fixed retry interval nor backoff factor is configured.");
+        } else if (isOnlyFixedIntervalConfigured()) {
+            throw new IllegalStateException(
+                    "If fixed retry interval is configured, then max retry count must also be configured.");
+        } else if (isOnlyBackoffFactorConfigured()) {
+            throw new IllegalStateException(
+                    "If fixed backoff factore is configured, then max retry count must also be configured.");
+        } else if (intervalRetrySchedulerIsConfigured() && exponentialBackoffIntervalRetrySchedulerIsConfigured()) {
+            throw new IllegalStateException("Only one of retry interval or backoff factor can be configured.");
+        } else if (customRetrySchedulerIsProvided()
+                && (intervalRetrySchedulerIsConfigured() || exponentialBackoffIntervalRetrySchedulerIsConfigured())) {
+            throw new IllegalStateException(
+                    "Either a custom RetryScheduler can be provided or one of retry interval or backoff factor can be configured.");
+        }
+        validateCustomRetrySchedulerProducer();
+    }
+
+    private boolean isOnlyBackoffFactorConfigured() {
+        return retryConfig().backoffFactor().isPresent() && retryConfig().maxRetryCount().isEmpty();
+    }
+
+    private boolean isOnlyFixedIntervalConfigured() {
+        return retryConfig().fixedRetryInterval().isPresent() && retryConfig().maxRetryCount().isEmpty();
+    }
+
+    private boolean isOnlyMaxRetryConfigured() {
+        return retryConfig().maxRetryCount().isPresent() &&
+                retryConfig().fixedRetryInterval().isEmpty() &&
+                retryConfig().backoffFactor().isEmpty();
+    }
+
+    private void validateCustomRetrySchedulerProducer() {
+        if (retrySchedulerProducer.isAmbiguous()) {
+            throw new IllegalStateException(
+                    "multiple retrySchedulerProducer found: %s"
+                            .formatted(retrySchedulerProducer.stream()
+                                    .map(Object::getClass)
+                                    .map(Class::getName)
+                                    .collect(Collectors.joining(", "))));
+        }
+    }
+
+    private boolean intervalRetrySchedulerIsConfigured() {
+        return retryConfig().fixedRetryInterval().isPresent() &&
+                retryConfig().maxRetryCount().isPresent();
+    }
+
+    private IntervalRetryScheduler intervalRetryScheduler() {
+        return new IntervalRetryScheduler.Builder()
+                .retryInterval(retryConfig().fixedRetryInterval().orElseThrow())
+                .maxRetryCount(retryConfig().maxRetryCount().orElseThrow())
+                .retryExecutor(executorService)
+                .build();
+    }
+
+    private AxonConfiguration.CommandRetryScheduling retryConfig() {
+        return axonConfiguration.commandGatewayRetryScheduling();
+    }
+
+    private boolean exponentialBackoffIntervalRetrySchedulerIsConfigured() {
+        return retryConfig().backoffFactor().isPresent() &&
+                retryConfig().maxRetryCount().isPresent();
+    }
+
+    private ExponentialBackOffIntervalRetryScheduler backoffIntervalRetryScheduler() {
+        return new ExponentialBackOffIntervalRetryScheduler.Builder()
+                .maxRetryCount(retryConfig().maxRetryCount().orElseThrow())
+                .backoffFactor(retryConfig().backoffFactor().orElseThrow())
+                .retryExecutor(executorService)
+                .build();
+    }
+
+    private boolean customRetrySchedulerIsProvided() {
+        return retrySchedulerProducer.isResolvable();
+    }
+
+    private RetryScheduler customRetryScheduler() {
+        return retrySchedulerProducer.get();
+    }
+}

--- a/core/runtime/src/test/java/at/meks/quarkiverse/axon/runtime/defaults/RetrySchedulerConfigurerTest.java
+++ b/core/runtime/src/test/java/at/meks/quarkiverse/axon/runtime/defaults/RetrySchedulerConfigurerTest.java
@@ -1,0 +1,201 @@
+package at.meks.quarkiverse.axon.runtime.defaults;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.gateway.ExponentialBackOffIntervalRetryScheduler;
+import org.axonframework.commandhandling.gateway.IntervalRetryScheduler;
+import org.axonframework.commandhandling.gateway.RetryScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import at.meks.quarkiverse.axon.runtime.conf.AxonConfiguration;
+
+@ExtendWith(MockitoExtension.class)
+class RetrySchedulerConfigurerTest {
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    Instance<RetryScheduler> retrySchedulerProducer;
+
+    @Mock
+    private AxonConfiguration axonConfiguration;
+
+    @InjectMocks
+    private RetrySchedulerConfigurer configurer;
+
+    @Mock
+    private AxonConfiguration.CommandRetryScheduling retryScheduling;
+
+    @SuppressWarnings("unused")
+    @Mock
+    private ScheduledExecutorService executorService;
+
+    @BeforeEach
+    void setUp() {
+        when(axonConfiguration.commandGatewayRetryScheduling()).thenReturn(retryScheduling);
+        configurer.axonConfiguration = axonConfiguration;
+        configurer.retrySchedulerProducer = retrySchedulerProducer;
+        when(retrySchedulerProducer.isUnsatisfied()).thenReturn(true);
+    }
+
+    @Test
+    void fixedIntervalIIsConfiguredValid() {
+        when(retryScheduling.fixedRetryInterval()).thenReturn(Optional.of(100));
+        when(retryScheduling.maxRetryCount()).thenReturn(Optional.of(3));
+
+        Optional<RetryScheduler> scheduler = configurer.retryScheduler();
+
+        assertTrue(scheduler.isPresent());
+        assertInstanceOf(IntervalRetryScheduler.class, scheduler.get());
+    }
+
+    @Test
+    void backoffIsConfiguredValid() {
+        when(retryScheduling.backoffFactor()).thenReturn(Optional.of(2));
+        when(retryScheduling.maxRetryCount()).thenReturn(Optional.of(3));
+
+        Optional<RetryScheduler> scheduler = configurer.retryScheduler();
+
+        assertTrue(scheduler.isPresent());
+        assertInstanceOf(ExponentialBackOffIntervalRetryScheduler.class, scheduler.get());
+    }
+
+    @Test
+    void fixedIntervalAndBackoffAreConfigured() {
+        when(retryScheduling.fixedRetryInterval()).thenReturn(Optional.of(100));
+        when(retryScheduling.backoffFactor()).thenReturn(Optional.of(2));
+        when(retryScheduling.maxRetryCount()).thenReturn(Optional.of(3));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, configurer::retryScheduler);
+
+        assertEquals("Only one of retry interval or backoff factor can be configured.", exception.getMessage());
+    }
+
+    @Test
+    void onlyMaxRetryCountIsConfigured() {
+        when(retryScheduling.maxRetryCount()).thenReturn(Optional.of(3));
+        when(retrySchedulerProducer.isUnsatisfied()).thenReturn(true);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, configurer::retryScheduler);
+
+        assertEquals(
+                "Retry Scheduler max retry count is configured but either fixed retry interval nor backoff factor is configured.",
+                exception.getMessage());
+    }
+
+    @Test
+    void fixedIntervalIsConfiguredInvalid() {
+        when(retryScheduling.fixedRetryInterval()).thenReturn(Optional.of(1));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, configurer::retryScheduler);
+
+        assertEquals(
+                "If fixed retry interval is configured, then max retry count must also be configured.",
+                exception.getMessage());
+    }
+
+    @Test
+    void backoffIsConfiguredInvalid() {
+        when(retryScheduling.backoffFactor()).thenReturn(Optional.of(1));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, configurer::retryScheduler);
+
+        assertEquals(
+                "If fixed backoff factore is configured, then max retry count must also be configured.",
+                exception.getMessage());
+    }
+
+    @Test
+    void testCustomRetrySchedulerProvided() {
+        RetryScheduler customRetryScheduler = mock(RetryScheduler.class);
+        when(retrySchedulerProducer.isResolvable()).thenReturn(true);
+        when(retrySchedulerProducer.isUnsatisfied()).thenReturn(false);
+        when(retrySchedulerProducer.get()).thenReturn(customRetryScheduler);
+
+        Optional<RetryScheduler> scheduler = configurer.retryScheduler();
+
+        assertTrue(scheduler.isPresent());
+        assertEquals(customRetryScheduler, scheduler.get());
+    }
+
+    @Test
+    void multipleRetrySchedulersProduced() {
+        when(retrySchedulerProducer.isResolvable()).thenReturn(false);
+        when(retrySchedulerProducer.isUnsatisfied()).thenReturn(false);
+        when(retrySchedulerProducer.isAmbiguous()).thenReturn(true);
+        when(retrySchedulerProducer.stream()).thenReturn(Stream.of(new Scheduler1(), new Scheduler2()));
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                configurer::retryScheduler);
+
+        assertEquals(
+                "multiple retrySchedulerProducer found: at.meks.quarkiverse.axon.runtime.defaults.RetrySchedulerConfigurerTest$Scheduler1, at.meks.quarkiverse.axon.runtime.defaults.RetrySchedulerConfigurerTest$Scheduler2",
+                illegalStateException.getMessage());
+    }
+
+    private static class Scheduler1 implements RetryScheduler {
+        @Override
+        public boolean scheduleRetry(CommandMessage commandMessage, RuntimeException lastFailure,
+                List<Class<? extends Throwable>[]> failures, Runnable commandDispatch) {
+            return false;
+        }
+    }
+
+    private static class Scheduler2 implements RetryScheduler {
+        @Override
+        public boolean scheduleRetry(CommandMessage commandMessage, RuntimeException lastFailure,
+                List<Class<? extends Throwable>[]> failures, Runnable commandDispatch) {
+            return false;
+        }
+
+    }
+
+    @Test
+    void noRetryIsConfigured() {
+        Optional<RetryScheduler> scheduler = configurer.retryScheduler();
+        assertTrue(scheduler.isEmpty());
+    }
+
+    @Test
+    void customSchedulerAndIntervalRetrySchedulerIsConfigured() {
+        when(retrySchedulerProducer.isResolvable()).thenReturn(true);
+        when(retrySchedulerProducer.stream()).thenReturn(Stream.of(new Scheduler1()));
+        when(retryScheduling.fixedRetryInterval()).thenReturn(Optional.of(100));
+        when(retryScheduling.maxRetryCount()).thenReturn(Optional.of(3));
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                configurer::retryScheduler);
+
+        assertEquals(
+                "Either a custom RetryScheduler can be provided or one of retry interval or backoff factor can be configured.",
+                illegalStateException.getMessage());
+    }
+
+    @Test
+    void customSchedulerAndBackoffSchedulerIsConfigured() {
+        when(retrySchedulerProducer.isResolvable()).thenReturn(true);
+        when(retrySchedulerProducer.stream()).thenReturn(Stream.of(new Scheduler1()));
+        when(retryScheduling.backoffFactor()).thenReturn(Optional.of(100));
+        when(retryScheduling.maxRetryCount()).thenReturn(Optional.of(3));
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                configurer::retryScheduler);
+
+        assertEquals(
+                "Either a custom RetryScheduler can be provided or one of retry interval or backoff factor can be configured.",
+                illegalStateException.getMessage());
+    }
+}

--- a/docs/modules/ROOT/pages/04-00-SetupAndUsage.adoc
+++ b/docs/modules/ROOT/pages/04-00-SetupAndUsage.adoc
@@ -18,13 +18,14 @@ Content
 * link:04-06-EventUpcasting.adoc[Event Upcasting]
 * link:04-07-Sagas.adoc[Sagas]
 * link:04-08-ExceptionHandling.adoc[Exception Handling]
-* link:04-09-Interceptors.adoc[Interceptors]
-* link:04-10-InjectCdiBeans.adoc[Inject CDI Beans into Message Handler Methods]
-* link:04-11-Transaction.adoc[Transaction]
-* link:04-12-Metrics.adoc[Metrics]
-* link:04-13-HealthChecks.adoc[HealthChecks]
-* link:04-14-AccessToAxonObjects.adoc[Access To Axon Objects]
-* link:04-15-Serialization.adoc[Serialization]
+* link:04-09-CommandGateway.adoc[CommandGateway]
+* link:04-10-Interceptors.adoc[Interceptors]
+* link:04-11-InjectCdiBeans.adoc[Inject CDI Beans into Message Handler Methods]
+* link:04-12-Transaction.adoc[Transaction]
+* link:04-13-Metrics.adoc[Metrics]
+* link:04-14-HealthChecks.adoc[HealthChecks]
+* link:04-15-AccessToAxonObjects.adoc[Access To Axon Objects]
+* link:04-16-Serialization.adoc[Serialization]
 
 
 '''

--- a/docs/modules/ROOT/pages/04-02-Snapshots.adoc
+++ b/docs/modules/ROOT/pages/04-02-Snapshots.adoc
@@ -15,7 +15,7 @@ a possibility is to add the annotation `@JsonAutoDetect(fieldVisibility = JsonAu
 
 This strategy was chosen because it doesn't have an impact on the serialization of other classes(e.g. the return values of Web Services).
 
-Another possibility is to provide your own serializers, see link:04-15-Serialization.adoc[Serialization].
+Another possibility is to provide your own serializers, see link:04-16-Serialization.adoc[Serialization].
 
 
 == Trigger Types

--- a/docs/modules/ROOT/pages/04-04-EventProcessors.adoc
+++ b/docs/modules/ROOT/pages/04-04-EventProcessors.adoc
@@ -1,5 +1,15 @@
 = Event Processors
 
+'''
+
+link:index.adoc[Index]
+
+link:04-03-CustomAggregateConfigurer.adoc[← Previous: Custom Aggregate Configurer]
+
+link:04-05-TokenStores.adoc[Next: Token Stores →]
+
+'''
+
 Event Processors are necessary for event handler.
 Those processors need to know which events are already processed.
 This information is stored in a token store.

--- a/docs/modules/ROOT/pages/04-05-TokenStores.adoc
+++ b/docs/modules/ROOT/pages/04-05-TokenStores.adoc
@@ -31,7 +31,7 @@ If you would like to use the JDBC Tokenstore, you simply have to add the depende
 By default the database table is created on startup. If you don't want to create the table automatically, you can disable the creation.
 
 CAUTION: Normally in production environment you need a proper transaction manager configured in the axon framework. For detailed information see
-link:04-11-Transaction.adoc[Transaction].
+link:04-12-Transaction.adoc[Transaction].
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/04-07-Sagas.adoc
+++ b/docs/modules/ROOT/pages/04-07-Sagas.adoc
@@ -58,7 +58,7 @@ public class CardReturnSaga {
     }
 }
 ----
-<1> Necessary annotation, that this Saga is registered with field for serialization, if the serializer cannot access fields(see link:04-15-Serialization.adoc[Serialization])
+<1> Necessary annotation, that this Saga is registered with field for serialization, if the serializer cannot access fields(see link:04-16-Serialization.adoc[Serialization])
 <2> An application scoped bean is injected. It must be transient because of serialization
 <3> the application scoped bean is used to do some necessary task
 <4> the application scoped bean is used to do some necessary task
@@ -81,7 +81,7 @@ If you would like to use the JDBC Sagastore, you simply have to add the dependen
 </dependency>
 ----
 
-NOTE: The dependency quarkus-axon-transaction for transaction management is automatically added. For detailed information see link:04-11-Transaction.adoc[Transaction].
+NOTE: The dependency quarkus-axon-transaction for transaction management is automatically added. For detailed information see link:04-12-Transaction.adoc[Transaction].
 
 By default the database table is created on startup. If you don't want to create the table automatically, you can disable the creation.
 

--- a/docs/modules/ROOT/pages/04-08-ExceptionHandling.adoc
+++ b/docs/modules/ROOT/pages/04-08-ExceptionHandling.adoc
@@ -28,4 +28,4 @@ link:index.adoc[Index]
 
 link:04-07-Sagas.adoc[← Previous: Sagas]
 
-link:04-09-Interceptors.adoc[Next: Interceptors →]
+link:04-09-CommandGateway.adoc[Next: CommandGateway →]

--- a/docs/modules/ROOT/pages/04-09-CommandGateway.adoc
+++ b/docs/modules/ROOT/pages/04-09-CommandGateway.adoc
@@ -1,0 +1,25 @@
+= Command Gateway
+
+== Retry Scheduler
+
+If you would like to provide another Retry Scheduler for the CommandGateway, all you have to do is to produce a scheduler implemention.
+
+[source,java]
+----
+@Produces
+@ApplicationScoped
+public RetryScheduler retryScheduler() {
+    return new IntervalRetryScheduler.Builder() // <1>
+            .retryInterval(1000)
+            .maxRetryCount(100).build();
+}
+----
+<1> This is a RetryScheduler of the Axon Framework
+
+'''
+
+link:index.adoc[Index]
+
+link:04-08-ExceptionHandling.adoc[← Previous: Exception Handling]
+
+link:04-10-Interceptors.adoc[Next: Interceptors →]

--- a/docs/modules/ROOT/pages/04-09-CommandGateway.adoc
+++ b/docs/modules/ROOT/pages/04-09-CommandGateway.adoc
@@ -2,6 +2,41 @@
 
 == Retry Scheduler
 
+== IntervalRetryScheduler
+
+If you want to use Axon's IntervalRetryScheduler you have to configure those properties:
+
+[source,properties]
+----
+quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval=100 # <1>
+quarkus.axon.command-gateway.retry.scheduling.max-retry-count=10
+----
+<1> ist the intervall in milliseconds
+
+The IntervalRetryScheduler will retry a given command at set intervals until it succeeds, or a maximum number of retries has taken place.
+
+For details please read the Axon Framework documentation.
+
+== ExponentialBackOffIntervalRetryScheduler
+
+If you want to use Axon's ExponentialBackOffIntervalRetryScheduler you have to configure those properties:
+
+[source,properties]
+----
+quarkus.axon.command-gateway.retry.scheduling.backoff-factor=100 # <1>
+quarkus.axon.command-gateway.retry.scheduling.max-retry-count=10
+----
+<1> ist the backoff factor in milliseconds
+
+The ExponentialBackOffIntervalRetryScheduler retries failed commands with an exponential back-off interval until it succeeds, or a maximum number of retries has taken place.
+
+For details please read the Axon Framework documentation.
+
+
+== BackoffRetryScheduler
+
+=== Custom Retry Scheduler
+
 If you would like to provide another Retry Scheduler for the CommandGateway, all you have to do is to produce a scheduler implemention.
 
 [source,java]

--- a/docs/modules/ROOT/pages/04-10-Interceptors.adoc
+++ b/docs/modules/ROOT/pages/04-10-Interceptors.adoc
@@ -96,4 +96,4 @@ link:index.adoc[Index]
 
 link:04-08-ExceptionHandling.adoc[← Previous: Exception Handling]
 
-link:04-10-InjectCdiBeans.adoc[Next: Inject CDI Beans into Message Handler Methods →]
+link:04-11-InjectCdiBeans.adoc[Next: Inject CDI Beans into Message Handler Methods →]

--- a/docs/modules/ROOT/pages/04-11-InjectCdiBeans.adoc
+++ b/docs/modules/ROOT/pages/04-11-InjectCdiBeans.adoc
@@ -23,6 +23,6 @@ void handle(MyCommand command, MyBean bean) {
 
 link:index.adoc[Index]
 
-link:04-09-Interceptors.adoc[← Previous: Interceptors]
+link:04-10-Interceptors.adoc[← Previous: Interceptors]
 
-link:04-11-Transaction.adoc[Next: Transaction →]
+link:04-12-Transaction.adoc[Next: Transaction →]

--- a/docs/modules/ROOT/pages/04-12-Transaction.adoc
+++ b/docs/modules/ROOT/pages/04-12-Transaction.adoc
@@ -19,6 +19,6 @@ It uses the quarkus transaction management configured into the axon framework.
 
 link:index.adoc[Index]
 
-link:04-10-InjectCdiBeans.adoc[← Previous: Inject CDI Beans into Message Handler Methods]
+link:04-11-InjectCdiBeans.adoc[← Previous: Inject CDI Beans into Message Handler Methods]
 
-link:04-12-Metrics.adoc[Next: Metrics →]
+link:04-13-Metrics.adoc[Next: Metrics →]

--- a/docs/modules/ROOT/pages/04-13-Metrics.adoc
+++ b/docs/modules/ROOT/pages/04-13-Metrics.adoc
@@ -30,6 +30,6 @@ include::includes/quarkus-axon-metrics.adoc[leveloffset=+1,opts=optional]
 
 link:index.adoc[Index]
 
-link:04-11-Transaction.adoc[← Previous: Transaction]
+link:04-12-Transaction.adoc[← Previous: Transaction]
 
-link:04-13-HealthChecks.adoc[Next: Health Checks →]
+link:04-14-HealthChecks.adoc[Next: Health Checks →]

--- a/docs/modules/ROOT/pages/04-14-HealthChecks.adoc
+++ b/docs/modules/ROOT/pages/04-14-HealthChecks.adoc
@@ -16,6 +16,6 @@ to false. Be aware that these settings are build-time settings. That means that 
 
 link:index.adoc[Index]
 
-link:04-12-Metrics.adoc[← Previous: Metrics]
+link:04-13-Metrics.adoc[← Previous: Metrics]
 
-link:04-14-AccessToAxonObjects.adoc[Next: Access To Axon Objects →]
+link:04-15-AccessToAxonObjects.adoc[Next: Access To Axon Objects →]

--- a/docs/modules/ROOT/pages/04-15-AccessToAxonObjects.adoc
+++ b/docs/modules/ROOT/pages/04-15-AccessToAxonObjects.adoc
@@ -16,6 +16,6 @@ you can simply inject it to your CDI bean. You can see example injections in lin
 
 link:index.adoc[Index]
 
-link:04-13-HealthChecks.adoc[← Previous: Health Checks]
+link:04-14-HealthChecks.adoc[← Previous: Health Checks]
 
-link:04-15-Serialization.adoc[Next: Serialization →]
+link:04-16-Serialization.adoc[Next: Serialization →]

--- a/docs/modules/ROOT/pages/04-16-Serialization.adoc
+++ b/docs/modules/ROOT/pages/04-16-Serialization.adoc
@@ -21,4 +21,4 @@ If your commands or queries or one of its classes in the object hierarchy doesn'
 
 link:index.adoc[Index]
 
-link:04-14-AccessToAxonObjects.adoc[← Previous: Access To Axon Objects]
+link:04-15-AccessToAxonObjects.adoc[← Previous: Access To Axon Objects]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -133,6 +133,69 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval[`quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The fixed retry interval for retry scheduling(IntervalRetryScheduler), if configured. The fixed retry interval specifies a consistent delay duration between retries. If a fixed retry interval is configured, a maximum retry count must also be specified to ensure proper retry behavior.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_FIXED_RETRY_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_FIXED_RETRY_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-max-retry-count]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-max-retry-count[`quarkus.axon.command-gateway.retry.scheduling.max-retry-count`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.max-retry-count+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+if you have configured either the `fixed-retry-interval()` or the `backoff-factor()` you must configure the maximum retries as well.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_MAX_RETRY_COUNT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_MAX_RETRY_COUNT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-backoff-factor]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-backoff-factor[`quarkus.axon.command-gateway.retry.scheduling.backoff-factor`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.backoff-factor+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+backoff factor for retry scheduling(ExponentialBackOffIntervalRetryScheduler). This value is used in conjunction with an exponential backoff retry mechanism, where the interval between retries increases over time based on this factor. If configured, the maximum retries must also be set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_BACKOFF_FACTOR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_BACKOFF_FACTOR+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.snapshots.trigger-type+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -133,6 +133,69 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval[`quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The fixed retry interval for retry scheduling(IntervalRetryScheduler), if configured. The fixed retry interval specifies a consistent delay duration between retries. If a fixed retry interval is configured, a maximum retry count must also be specified to ensure proper retry behavior.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_FIXED_RETRY_INTERVAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_FIXED_RETRY_INTERVAL+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-max-retry-count]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-max-retry-count[`quarkus.axon.command-gateway.retry.scheduling.max-retry-count`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.max-retry-count+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+if you have configured either the `fixed-retry-interval()` or the `backoff-factor()` you must configure the maximum retries as well.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_MAX_RETRY_COUNT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_MAX_RETRY_COUNT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-backoff-factor]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-backoff-factor[`quarkus.axon.command-gateway.retry.scheduling.backoff-factor`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.backoff-factor+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+backoff factor for retry scheduling(ExponentialBackOffIntervalRetryScheduler). This value is used in conjunction with an exponential backoff retry mechanism, where the interval between retries increases over time based on this factor. If configured, the maximum retries must also be set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_BACKOFF_FACTOR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_GATEWAY_RETRY_SCHEDULING_BACKOFF_FACTOR+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.snapshots.trigger-type+++[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,6 +1,10 @@
 = Quarkus Axonframework Extension
 include::./includes/attributes.adoc[]
 
+link:01-AboutAxonFramework.adoc[Next: What is Axon Framework? →]
+
+'''
+
 == Index
 This guide explains how to use quarkus together with the axon framework.
 
@@ -13,3 +17,6 @@ This guide explains how to use quarkus together with the axon framework.
 == Core Configuration Reference
 include::includes/quarkus-axon.adoc[leveloffset=+1,opts=optional]
 
+'''
+
+link:01-AboutAxonFramework.adoc[Next: What is Axon Framework? →]

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -4,3 +4,5 @@ quarkus.axon.eventstore.jdbc.event-table-name=JdbcDomainEventEntry
 quarkus.axon.tokenstore.jdbc.token-table-name=JdbcTokenEntry
 quarkus.axon.snapshots.trigger-type=event-count
 quarkus.axon.snapshots.threshold=2
+quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval=100
+quarkus.axon.command-gateway.retry.scheduling.max-retry-count=10


### PR DESCRIPTION
A RetryScheduler can be now configured in the application.properties.
Either the Backoff or the IntervalRetryScheduler can be configured.

It that's not enough a RetryScheduler can be produced.