### PR TITLE
Support for configuration of DuplicateCommandHandlerResolver

### DIFF
--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandhandler/CustomCommandBusTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandhandler/CustomCommandBusTest.java
@@ -9,7 +9,7 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.config.Configuration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import at.meks.quarkiverse.axon.runtime.customizations.CommandBusConfigurer;
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusProducer;
 import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -18,10 +18,10 @@ public class CustomCommandBusTest extends JavaArchiveTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
-                    .addClasses(MyCommandBusConfigurer.class));
+                    .addClasses(MyCommandBusProducer.class));
 
     @ApplicationScoped
-    public static class MyCommandBusConfigurer implements CommandBusConfigurer {
+    public static class MyCommandBusProducer implements CommandBusProducer {
 
         @Override
         public CommandBus createCommandBus(Configuration configuration) {

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandhandler/MoreCommandHandlerConfigurerTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandhandler/MoreCommandHandlerConfigurerTest.java
@@ -6,14 +6,14 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.config.Configuration;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import at.meks.quarkiverse.axon.runtime.customizations.CommandBusConfigurer;
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusProducer;
 import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class MoreCommandHandlerConfigurerTest extends JavaArchiveTest {
 
     @ApplicationScoped
-    public static class CommandHandlerConfigurer1 implements CommandBusConfigurer {
+    public static class CommandHandlerProducer1 implements CommandBusProducer {
 
         @Override
         public CommandBus createCommandBus(Configuration configuration) {
@@ -23,7 +23,7 @@ public class MoreCommandHandlerConfigurerTest extends JavaArchiveTest {
     }
 
     @ApplicationScoped
-    public static class CommandHandlerConfigurer2 implements CommandBusConfigurer {
+    public static class CommandHandlerProducer2 implements CommandBusProducer {
 
         @Override
         public CommandBus createCommandBus(Configuration configuration) {
@@ -36,6 +36,6 @@ public class MoreCommandHandlerConfigurerTest extends JavaArchiveTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setExpectedException(IllegalStateException.class, true)
             .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
-                    .addClasses(CommandHandlerConfigurer1.class, CommandHandlerConfigurer2.class));
+                    .addClasses(CommandHandlerProducer1.class, CommandHandlerProducer2.class));
 
 }

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandhandler/duplicatecommandresolver/RejectDuplicatesTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/commandhandler/duplicatecommandresolver/RejectDuplicatesTest.java
@@ -1,0 +1,32 @@
+package at.meks.quarkiverse.axon.deployment.commandhandler.duplicatecommandresolver;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.model.Api;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RejectDuplicatesTest extends JavaArchiveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(LifecycleHandlerInvocationException.class)
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClass(MyCommandHandler.class)
+                    .addAsResource(propertiesFile("/commandhandler/duplicateResolver/rejectDuplicates.properties"),
+                            "application.properties"));
+
+    @ApplicationScoped
+    public static class MyCommandHandler {
+
+        @CommandHandler
+        public void handle(Api.IssueCardCommand command) {
+
+        }
+    }
+
+}

--- a/core/deployment/src/test/resources/commandhandler/duplicateresolver/rejectDuplicates.properties
+++ b/core/deployment/src/test/resources/commandhandler/duplicateresolver/rejectDuplicates.properties
@@ -1,0 +1,1 @@
+quarkus.axon.command-bus.duplicate-command-handler-resolver=rejectDuplicates

--- a/core/deployment/src/test/resources/live/reloading/application.properties
+++ b/core/deployment/src/test/resources/live/reloading/application.properties
@@ -3,3 +3,5 @@
 #quarkus.log.category."at.meks.quarkiverse.axon.runtime.AxonExtension".level=DEBUG
 # Using the test port prevents the problem if a quarkus instance was started manually
 quarkus.http.port=8081
+# to be able to use the domain service for live reloading tests, the duplicate handler was set to logAndOverride, that no exception happens on startup
+quarkus.axon.command-bus.duplicate-command-handler-resolver=logAndOverride

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
@@ -48,6 +48,11 @@ public interface AxonConfiguration {
     CommandRetryScheduling commandGatewayRetryScheduling();
 
     /**
+     * configuration for the local command bus.
+     */
+    CommandBusConfiguration commandBus();
+
+    /**
      * Live reloading needs a wait time, to wait for axon's framework or axon's server to cleanup. This wait time seems
      * to be dependent on the hardware. The default configuration works well on a MacBook Pro with M1 Chip.
      * If you get the error that no command handler is available after a reload, increase the wait time until this
@@ -150,4 +155,14 @@ public interface AxonConfiguration {
         Optional<Integer> backoffFactor();
     }
 
+    interface CommandBusConfiguration {
+
+        /**
+         * Configure how duplicate commands are handled. If not set, the defaults of the Axonframework are used.
+         */
+        @WithName("duplicate-command-handler-resolver")
+        @WithDefault("rejectDuplicates")
+        DuplicateCommandHandlerResolverType duplicateCommandHandlerResolverType();
+
+    }
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/DuplicateCommandHandlerResolverType.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/DuplicateCommandHandlerResolverType.java
@@ -1,0 +1,7 @@
+package at.meks.quarkiverse.axon.runtime.conf;
+
+public enum DuplicateCommandHandlerResolverType {
+    logAndOverride,
+    silentOverride,
+    rejectDuplicates
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/CommandBusBuilder.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/CommandBusBuilder.java
@@ -1,0 +1,15 @@
+package at.meks.quarkiverse.axon.runtime.customizations;
+
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
+import org.axonframework.config.Configuration;
+
+/**
+ * A builder interface for creating instances of {@link CommandBus} with customizable configurations.
+ */
+public interface CommandBusBuilder {
+
+    CommandBusBuilder duplicateCommandHandlerResolver(DuplicateCommandHandlerResolver resolver);
+
+    CommandBus build(Configuration configuration);
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/CommandBusProducer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/CommandBusProducer.java
@@ -1,0 +1,14 @@
+package at.meks.quarkiverse.axon.runtime.customizations;
+
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.config.Configuration;
+
+/**
+ * This interface is thought for those cases where a CommandBus is needed, which is not setup
+ * by the extension as needed.
+ */
+public interface CommandBusProducer {
+
+    CommandBus createCommandBus(Configuration configuration);
+
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/CommandBusConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/CommandBusConfigurer.java
@@ -1,0 +1,76 @@
+package at.meks.quarkiverse.axon.runtime.defaults;
+
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.DuplicateCommandHandlerResolution;
+import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
+import org.axonframework.config.Configuration;
+import org.axonframework.config.Configurer;
+
+import at.meks.quarkiverse.axon.runtime.conf.AxonConfiguration;
+import at.meks.quarkiverse.axon.runtime.conf.DuplicateCommandHandlerResolverType;
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusBuilder;
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusProducer;
+
+@Dependent
+class CommandBusConfigurer {
+
+    @Inject
+    Instance<CommandBusProducer> commandBusProducer;
+
+    @Inject
+    CommandBusBuilder commandBusBuilder;
+
+    @Inject
+    AxonConfiguration axonConfiguration;
+
+    void configureCommandBus(Configurer configurer) {
+        verifyProvidedBeans();
+        if (commandBusProducer.isResolvable()) {
+            configureCommandBusUsingCustomProducer(configurer);
+        } else {
+            configureCommandBusUsingBuilder(configurer);
+        }
+    }
+
+    private void verifyProvidedBeans() {
+        if (commandBusProducer.isAmbiguous()) {
+            throw new IllegalStateException(
+                    "multiple commandBusProducers found: %s"
+                            .formatted(commandBusProducer.stream().map(Object::getClass).map(Class::getName).collect(
+                                    Collectors.joining(", "))));
+        }
+    }
+
+    private void configureCommandBusUsingCustomProducer(Configurer configurer) {
+        configurer.configureCommandBus(configuration -> commandBusProducer.get().createCommandBus(configuration));
+    }
+
+    private void configureCommandBusUsingBuilder(Configurer configurer) {
+        configurer.configureCommandBus(this::createCommandBusWithBuilder);
+    }
+
+    private CommandBus createCommandBusWithBuilder(Configuration axonConfiguration) {
+        return commandBusBuilder
+                .duplicateCommandHandlerResolver(toResolver(duplicateCommandHandlerResolverType()))
+                .build(axonConfiguration);
+    }
+
+    private DuplicateCommandHandlerResolverType duplicateCommandHandlerResolverType() {
+        return axonConfiguration.commandBus().duplicateCommandHandlerResolverType();
+    }
+
+    private DuplicateCommandHandlerResolver toResolver(DuplicateCommandHandlerResolverType resolverType) {
+        return switch (resolverType) {
+            case logAndOverride -> DuplicateCommandHandlerResolution.logAndOverride();
+            case rejectDuplicates -> DuplicateCommandHandlerResolution.rejectDuplicates();
+            case silentOverride -> DuplicateCommandHandlerResolution.silentOverride();
+        };
+    }
+
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
@@ -65,7 +65,7 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
     RetrySchedulerConfigurer retrySchedulerConfigurer;
 
     @Inject
-    Instance<CommandBusConfigurer> commandBusConfigurer;
+    CommandBusConfigurer commandBusConfigurer;
 
     private Set<Class<?>> aggregateClasses;
     private Set<Object> eventhandlers;
@@ -91,7 +91,7 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
         registerInjectableBeans(configurer);
         registerEventUpcasters(configurer);
         configureSagas(configurer);
-        configureCommandBus(configurer);
+        commandBusConfigurer.configureCommandBus(configurer);
         configureCommandGateway(configurer);
         return configurer;
     }
@@ -174,16 +174,6 @@ class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
                 .commandBus(conf.commandBus())
                 .retryScheduler(retryScheduler)
                 .build();
-    }
-
-    private void configureCommandBus(Configurer configurer) {
-        if (commandBusConfigurer.isResolvable()) {
-            configurer.configureCommandBus(configuration -> commandBusConfigurer.get().createCommandBus(configuration));
-        } else if (commandBusConfigurer.isAmbiguous()) {
-            throw new IllegalStateException(
-                    "multiple commandBusConfigurers found: %s"
-                            .formatted(commandBusConfigurer.stream().map(Object::getClass).map(Class::getName).toList()));
-        }
     }
 
     @Override

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/LocalCommandBusBuilder.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/LocalCommandBusBuilder.java
@@ -1,0 +1,36 @@
+package at.meks.quarkiverse.axon.runtime.defaults;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.Dependent;
+
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
+import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
+import org.axonframework.commandhandling.SimpleCommandBus;
+import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.config.Configuration;
+
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusBuilder;
+import io.quarkus.arc.DefaultBean;
+
+@Dependent
+@DefaultBean
+public class LocalCommandBusBuilder implements CommandBusBuilder {
+
+    private DuplicateCommandHandlerResolver resolver;
+
+    public CommandBusBuilder duplicateCommandHandlerResolver(DuplicateCommandHandlerResolver resolver) {
+        this.resolver = resolver;
+        return this;
+    }
+
+    public CommandBus build(Configuration config) {
+        SimpleCommandBus.Builder builder = SimpleCommandBus.builder()
+                .transactionManager(config.getComponent(TransactionManager.class))
+                .spanFactory(DefaultCommandBusSpanFactory.builder().spanFactory(config.spanFactory()).build())
+                .messageMonitor(config.messageMonitor(SimpleCommandBus.class, "commandBus"));
+        Optional.ofNullable(resolver).ifPresent(builder::duplicateCommandHandlerResolver);
+        return builder.build();
+    }
+}

--- a/core/runtime/src/test/java/at/meks/quarkiverse/axon/runtime/defaults/CommandBusConfigurerTest.java
+++ b/core/runtime/src/test/java/at/meks/quarkiverse/axon/runtime/defaults/CommandBusConfigurerTest.java
@@ -1,0 +1,95 @@
+package at.meks.quarkiverse.axon.runtime.defaults;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.config.Configuration;
+import org.axonframework.config.Configurer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusBuilder;
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusProducer;
+
+@ExtendWith(MockitoExtension.class)
+class CommandBusConfigurerTest {
+
+    @Mock
+    CommandBusBuilder commandBusBuilder;
+
+    @Mock
+    Instance<CommandBusProducer> commandBusProducer;
+
+    @Mock
+    Configurer axonConfigurer;
+
+    @InjectMocks
+    CommandBusConfigurer configurer;
+
+    private static class CommandBusProducer1 implements CommandBusProducer {
+        @Override
+        public CommandBus createCommandBus(Configuration configuration) {
+            return null;
+        }
+    }
+
+    private static class CommandBusProducer2 implements CommandBusProducer {
+        @Override
+        public CommandBus createCommandBus(Configuration configuration) {
+            return null;
+        }
+    }
+
+    @Nested
+    class InvalidBeansProvided {
+
+        @Test
+        void producerIsAmbigious() {
+            when(commandBusProducer.isAmbiguous())
+                    .thenReturn(true);
+            when(commandBusProducer.stream())
+                    .thenReturn(Stream.of(new CommandBusProducer1(), new CommandBusProducer2()));
+
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> configurer.configureCommandBus(axonConfigurer))
+                    .withMessage("multiple commandBusProducers found: %s",
+                            "at.meks.quarkiverse.axon.runtime.defaults.CommandBusConfigurerTest$CommandBusProducer1, " +
+                                    "at.meks.quarkiverse.axon.runtime.defaults.CommandBusConfigurerTest$CommandBusProducer2");
+        }
+
+    }
+
+    @Test
+    void producerIsResolvable() {
+        when(commandBusProducer.isResolvable()).thenReturn(true);
+        CommandBusProducer expectedCommandProducer = Mockito.mock(CommandBusProducer.class);
+        when(commandBusProducer.get()).thenReturn(expectedCommandProducer);
+
+        configurer.configureCommandBus(axonConfigurer);
+
+        var functionCaptor = commandBusFunctionCaptor();
+        verify(axonConfigurer).configureCommandBus(functionCaptor.capture());
+        functionCaptor.getValue().apply(Mockito.mock(Configuration.class));
+        verify(expectedCommandProducer).createCommandBus(Mockito.any());
+
+        verifyNoInteractions(commandBusBuilder);
+    }
+
+    private ArgumentCaptor<Function<Configuration, CommandBus>> commandBusFunctionCaptor() {
+        //noinspection unchecked
+        return ArgumentCaptor.forClass(Function.class);
+    }
+
+}

--- a/docs/modules/ROOT/pages/05-09-CommandBus.adoc
+++ b/docs/modules/ROOT/pages/05-09-CommandBus.adoc
@@ -1,10 +1,27 @@
 = Command Bus
 
-== Default Behaviour
+== DuplicateCommandHandlerResolver
 
-The Command Bus is initialized with the default of the Axon Framework.
+Axon provides three different behaviors, how the framework handles duplicate commands.
+You can configure your preferred behavior in the application.properties file.
 
-This also includes the special CommandBus, if the Axon Server is used as EventStore.
+[source,properties]
+----
+quarkus.axon.command-bus.duplicate-command-handler-resolver=rejectDuplicates
+----
+
+The possible values are
+
+* rejectDuplicates
+* logAndOverride
+* silentOverride
+
+When the application starts and a duplicate command handler is detected by the axon framework, the configured resolver
+will be executed. In the case of `rejectDuplicates` an exception occurs during startup.
+
+This behavior is also considered if you are using the Axon Server.
+
+The default is `rejectDuplicates`, to avoid unexpected behavior.
 
 == Custom Command Bus
 

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -196,6 +196,27 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-axon_quarkus-axon-command-bus-duplicate-command-handler-resolver]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-bus-duplicate-command-handler-resolver[`quarkus.axon.command-bus.duplicate-command-handler-resolver`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-bus.duplicate-command-handler-resolver+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Configure how duplicate commands are handled. If not set, the defaults of the Axonframework are used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_BUS_DUPLICATE_COMMAND_HANDLER_RESOLVER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_BUS_DUPLICATE_COMMAND_HANDLER_RESOLVER+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`log-and-override`, `silent-override`, `reject-duplicates`
+|`reject-duplicates`
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.snapshots.trigger-type+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -196,6 +196,27 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-axon_quarkus-axon-command-bus-duplicate-command-handler-resolver]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-bus-duplicate-command-handler-resolver[`quarkus.axon.command-bus.duplicate-command-handler-resolver`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.command-bus.duplicate-command-handler-resolver+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Configure how duplicate commands are handled. If not set, the defaults of the Axonframework are used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_COMMAND_BUS_DUPLICATE_COMMAND_HANDLER_RESOLVER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_COMMAND_BUS_DUPLICATE_COMMAND_HANDLER_RESOLVER+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`log-and-override`, `silent-override`, `reject-duplicates`
+|`reject-duplicates`
+
 a| [[quarkus-axon_quarkus-axon-snapshots-trigger-type]] [.property-path]##link:#quarkus-axon_quarkus-axon-snapshots-trigger-type[`quarkus.axon.snapshots.trigger-type`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.snapshots.trigger-type+++[]

--- a/eventstores/axon-server/deployment/src/main/java/at/meks/quarkiverse/axon/server/deployment/AxonServerProcessor.java
+++ b/eventstores/axon-server/deployment/src/main/java/at/meks/quarkiverse/axon/server/deployment/AxonServerProcessor.java
@@ -6,6 +6,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import at.meks.quarkiverse.axon.server.runtime.AxonServerCommandBusBuilder;
 import at.meks.quarkiverse.axon.server.runtime.AxonServerConfigurer;
 import at.meks.quarkiverse.axon.server.runtime.QuarkusAxonServerBuildTimeConfiguration;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -30,6 +31,14 @@ public class AxonServerProcessor {
     AdditionalBeanBuildItem tokenStoreConfigurer() {
         return AdditionalBeanBuildItem.builder()
                 .addBeanClass(AxonServerConfigurer.class)
+                .build();
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem axonServerCommandBusBuilder() {
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClass(AxonServerCommandBusBuilder.class)
+                .setUnremovable()
                 .build();
     }
 

--- a/eventstores/axon-server/deployment/src/test/java/at/meks/quarkiverse/axon/server/deployment/RejectDuplicatesTest.java
+++ b/eventstores/axon-server/deployment/src/test/java/at/meks/quarkiverse/axon/server/deployment/RejectDuplicatesTest.java
@@ -1,0 +1,32 @@
+package at.meks.quarkiverse.axon.server.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.shared.model.Api;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RejectDuplicatesTest extends JavaArchiveTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(LifecycleHandlerInvocationException.class)
+            .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                    .addClass(MyCommandHandler.class)
+                    .addAsResource(propertiesFile("/rejectDuplicates.properties"),
+                            "application.properties"));
+
+    @ApplicationScoped
+    public static class MyCommandHandler {
+
+        @CommandHandler
+        public void handle(Api.IssueCardCommand command) {
+
+        }
+    }
+
+}

--- a/eventstores/axon-server/deployment/src/test/resources/rejectDuplicates.properties
+++ b/eventstores/axon-server/deployment/src/test/resources/rejectDuplicates.properties
@@ -1,0 +1,1 @@
+quarkus.axon.command-bus.duplicate-command-handler-resolver=rejectDuplicates

--- a/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/AxonServerCommandBusBuilder.java
+++ b/eventstores/axon-server/runtime/src/main/java/at/meks/quarkiverse/axon/server/runtime/AxonServerCommandBusBuilder.java
@@ -1,0 +1,53 @@
+package at.meks.quarkiverse.axon.server.runtime;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
+import org.axonframework.axonserver.connector.command.CommandPriorityCalculator;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
+import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
+import org.axonframework.config.Configuration;
+
+import at.meks.quarkiverse.axon.runtime.customizations.CommandBusBuilder;
+import at.meks.quarkiverse.axon.runtime.defaults.LocalCommandBusBuilder;
+import io.quarkus.arc.DefaultBean;
+
+@Dependent
+@DefaultBean
+@Priority(5)
+public class AxonServerCommandBusBuilder implements CommandBusBuilder {
+
+    @Inject
+    LocalCommandBusBuilder localCommandBusBuilder;
+
+    private DuplicateCommandHandlerResolver duplicateResolver;
+
+    @Override
+    public CommandBusBuilder duplicateCommandHandlerResolver(DuplicateCommandHandlerResolver resolver) {
+        this.duplicateResolver = resolver;
+        return this;
+    }
+
+    @Override
+    public CommandBus build(Configuration configuration) {
+        AxonServerConfiguration axonServerConfiguration = configuration.getComponent(AxonServerConfiguration.class);
+        return AxonServerCommandBus.builder()
+                .localSegment(
+                        localCommandBusBuilder.duplicateCommandHandlerResolver(duplicateResolver).build(configuration))
+                .configuration(axonServerConfiguration)
+                .axonServerConnectionManager(AxonServerConnectionManager.builder()
+                        .axonServerConfiguration(axonServerConfiguration)
+                        .build())
+                .defaultContext(axonServerConfiguration.getContext())
+                .serializer(configuration.serializer())
+                .routingStrategy(AnnotationRoutingStrategy.defaultStrategy())
+                .priorityCalculator(CommandPriorityCalculator.defaultCommandPriorityCalculator())
+                .build();
+    }
+
+}


### PR DESCRIPTION
The DuplicateCommandHandlerResolver can now be configured in the application.properties