### PR TITLE
#175 Support Multi-Entity Aggregates with Command-Handler in AggregateMember

### DIFF
--- a/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/AxonExtensionProcessor.java
+++ b/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/AxonExtensionProcessor.java
@@ -189,6 +189,7 @@ class AxonExtensionProcessor {
     private @NotNull Stream<Class<?>> commandhandlerClasses(BeanArchiveIndexBuildItem beanArchiveIndex) {
         return annotatedClasses(CommandHandler.class, "commandhandlers",
                 annotationInstance -> annotationInstance.target().asMethod().declaringClass(), beanArchiveIndex)
+                .filter(clz -> clz.isAnnotationPresent(ApplicationScoped.class))
                 .filter(commandhandlerClass -> aggregateClasses(beanArchiveIndex)
                         .noneMatch(commandhandlerClass::equals));
     }

--- a/docs/modules/ROOT/pages/05-00-SetupAndUsage.adoc
+++ b/docs/modules/ROOT/pages/05-00-SetupAndUsage.adoc
@@ -10,22 +10,24 @@ E.g., how to
 
 Content
 
-* link:05-01-EventStores.adoc[Event Stores]
-* link:05-02-Snapshots.adoc[Snapshots]
-* link:05-03-CustomAggregateConfigurer.adoc[Custom Aggregate Configurer]
-* link:05-04-EventProcessors.adoc[Event Processors]
-* link:05-05-TokenStores.adoc[Token Stores]
-* link:05-06-EventUpcasting.adoc[Event Upcasting]
-* link:05-07-Sagas.adoc[Sagas]
-* link:05-08-ExceptionHandling.adoc[Exception Handling]
-* link:05-10-CommandGateway.adoc[CommandGateway]
-* link:05-11-Interceptors.adoc[Interceptors]
-* link:05-12-InjectCdiBeans.adoc[Inject CDI Beans into Message Handler Methods]
-* link:05-13-Transaction.adoc[Transaction]
-* link:05-14-Metrics.adoc[Metrics]
-* link:05-15-HealthChecks.adoc[HealthChecks]
-* link:05-16-AccessToAxonObjects.adoc[Access To Axon Objects]
-* link:05-17-Serialization.adoc[Serialization]
+* link:05-01-CommandHandler.adoc[Event Stores]
+* link:05-02-EventStores.adoc[Event Stores]
+* link:05-03-Snapshots.adoc[Snapshots]
+* link:05-04-CustomAggregateConfigurer.adoc[Custom Aggregate Configurer]
+* link:05-05-EventProcessors.adoc[Event Processors]
+* link:05-06-TokenStores.adoc[Token Stores]
+* link:05-07-EventUpcasting.adoc[Event Upcasting]
+* link:05-08-Sagas.adoc[Sagas]
+* link:05-09-ExceptionHandling.adoc[Exception Handling]
+* link:05-10-CommandBus.adoc[CommandBus]
+* link:05-11-CommandGateway.adoc[CommandGateway]
+* link:05-12-Interceptors.adoc[Interceptors]
+* link:05-13-InjectCdiBeans.adoc[Inject CDI Beans into Message Handler Methods]
+* link:05-14-Transaction.adoc[Transaction]
+* link:05-15-Metrics.adoc[Metrics]
+* link:05-16-HealthChecks.adoc[HealthChecks]
+* link:05-17-AccessToAxonObjects.adoc[Access To Axon Objects]
+* link:05-18-Serialization.adoc[Serialization]
 
 
 '''
@@ -33,4 +35,4 @@ link:index.adoc[Index]
 
 link:04-CreateApplication.adoc[← Previous: Creating an Event Sourcing Application]
 
-link:05-01-EventStores.adoc[Next: Event Stores →]
+link:05-01-CommandHandler.adoc[Next: Command Handler →]

--- a/docs/modules/ROOT/pages/05-01-CommandHandler.adoc
+++ b/docs/modules/ROOT/pages/05-01-CommandHandler.adoc
@@ -1,0 +1,18 @@
+= CommandHandler
+:toc:
+:toclevels: 3
+
+The annotation `@CommandHandler` can be set on methods of
+
+* Root Aggregates
+* Entities which are annotated with `@AggregateMember` at the field declaration of a Root Aggregate or another Entity
+* ApplicationScoped CDI Bean
+
+If the annotation `@CommandHandler` is used in a class which doesn't match to one of the three conditions above, it will not be registered in the Axon Framwork. This means that the Command Handler will not be found for the Command of this annotated method at runtime.
+
+'''
+link:index.adoc[Index]
+
+link:05-00-SetupAndUsage.adoc[← Previous: Setup & Usage]
+
+link:05-02-EventStores.adoc[Next: EventStores →]

--- a/docs/modules/ROOT/pages/05-02-EventStores.adoc
+++ b/docs/modules/ROOT/pages/05-02-EventStores.adoc
@@ -5,9 +5,9 @@
 '''
 link:index.adoc[Index]
 
-link:05-00-SetupAndUsage.adoc[← Previous: Setup & Usage]
+link:05-01-CommandHandler.adoc[← Previous: CommandHandler]
 
-link:05-02-Snapshots.adoc[Next: Snapshots →]
+link:05-03-Snapshots.adoc[Next: Snapshots →]
 
 '''
 
@@ -135,6 +135,6 @@ include::includes/quarkus-axon-jdbc-eventstore.adoc[leveloffset=+1,opts=optional
 '''
 link:index.adoc[Index]
 
-link:05-00-SetupAndUsage.adoc[← Previous: Setup & Usage]
+link:05-01-CommandHandler.adoc[← Previous: CommandHandler]
 
-link:05-02-Snapshots.adoc[Next: Snapshots →]
+link:05-03-Snapshots.adoc[Next: Snapshots →]

--- a/docs/modules/ROOT/pages/05-03-Snapshots.adoc
+++ b/docs/modules/ROOT/pages/05-03-Snapshots.adoc
@@ -15,7 +15,7 @@ a possibility is to add the annotation `@JsonAutoDetect(fieldVisibility = JsonAu
 
 This strategy was chosen because it doesn't have an impact on the serialization of other classes(e.g. the return values of Web Services).
 
-Another possibility is to provide your own serializers, see link:05-17-Serialization.adoc[Serialization].
+Another possibility is to provide your own serializers, see link:05-18-Serialization.adoc[Serialization].
 
 
 == Trigger Types
@@ -52,6 +52,6 @@ quarkus.axon.snapshots."at.meks.quarkiverse.axon.shared.model.Giftcard".threshol
 
 link:index.adoc[Index]
 
-link:05-01-EventStores.adoc[← Previous: Event Stores]
+link:05-02-EventStores.adoc[← Previous: Event Stores]
 
-link:05-03-CustomAggregateConfigurer.adoc[Next: Custom Aggregate Configurer →]
+link:05-04-CustomAggregateConfigurer.adoc[Next: Custom Aggregate Configurer →]

--- a/docs/modules/ROOT/pages/05-04-CustomAggregateConfigurer.adoc
+++ b/docs/modules/ROOT/pages/05-04-CustomAggregateConfigurer.adoc
@@ -8,6 +8,6 @@ For each Aggregate, the method `createConfigurer` is invoked. This method has to
 
 link:index.adoc[Index]
 
-link:05-02-Snapshots.adoc[← Previous: Snapshots]
+link:05-03-Snapshots.adoc[← Previous: Snapshots]
 
-link:05-04-EventProcessors.adoc[Next: Event Processors →]
+link:05-05-EventProcessors.adoc[Next: Event Processors →]

--- a/docs/modules/ROOT/pages/05-05-EventProcessors.adoc
+++ b/docs/modules/ROOT/pages/05-05-EventProcessors.adoc
@@ -4,9 +4,9 @@
 
 link:index.adoc[Index]
 
-link:05-03-CustomAggregateConfigurer.adoc[← Previous: Custom Aggregate Configurer]
+link:05-04-CustomAggregateConfigurer.adoc[← Previous: Custom Aggregate Configurer]
 
-link:05-05-TokenStores.adoc[Next: Token Stores →]
+link:05-06-TokenStores.adoc[Next: Token Stores →]
 
 '''
 
@@ -26,7 +26,7 @@ The artifact ids are:
 
 With the exception of the persistent stream, the other processors need a token store where the information is stored, which events were already processed.
 
-For more details on how to add a persistent token store, read link:05-05-TokenStores.adoc[Token Stores].
+For more details on how to add a persistent token store, read link:05-06-TokenStores.adoc[Token Stores].
 
 For details about the different event processors and the token store,
 please read the documentation of the Axon framework.
@@ -50,6 +50,6 @@ include::includes/quarkus-axon-pooled-eventprocessor.adoc[leveloffset=+1,opts=op
 
 link:index.adoc[Index]
 
-link:05-03-CustomAggregateConfigurer.adoc[← Previous: Custom Aggregate Configurer]
+link:05-04-CustomAggregateConfigurer.adoc[← Previous: Custom Aggregate Configurer]
 
-link:05-05-TokenStores.adoc[Next: Token Stores →]
+link:05-06-TokenStores.adoc[Next: Token Stores →]

--- a/docs/modules/ROOT/pages/05-06-TokenStores.adoc
+++ b/docs/modules/ROOT/pages/05-06-TokenStores.adoc
@@ -6,9 +6,9 @@
 
 link:index.adoc[Index]
 
-link:05-04-EventProcessors.adoc[← Previous: Event Processors]
+link:05-05-EventProcessors.adoc[← Previous: Event Processors]
 
-link:05-06-EventUpcasting.adoc[Next: Event Upcasting →]
+link:05-07-EventUpcasting.adoc[Next: Event Upcasting →]
 
 '''
 
@@ -31,7 +31,7 @@ If you would like to use the JDBC Tokenstore, you simply have to add the depende
 By default the database table is created on startup. If you don't want to create the table automatically, you can disable the creation.
 
 CAUTION: Normally in production environment you need a proper transaction manager configured in the axon framework. For detailed information see
-link:05-13-Transaction.adoc[Transaction].
+link:05-14-Transaction.adoc[Transaction].
 
 [source,properties]
 ----
@@ -98,6 +98,6 @@ include::includes/quarkus-axon-tokenstore-jpa.adoc[leveloffset=+1,opts=optional]
 
 link:index.adoc[Index]
 
-link:05-04-EventProcessors.adoc[← Previous: Event Processors]
+link:05-05-EventProcessors.adoc[← Previous: Event Processors]
 
-link:05-06-EventUpcasting.adoc[Next: Event Upcasting →]
+link:05-07-EventUpcasting.adoc[Next: Event Upcasting →]

--- a/docs/modules/ROOT/pages/05-07-EventUpcasting.adoc
+++ b/docs/modules/ROOT/pages/05-07-EventUpcasting.adoc
@@ -19,6 +19,6 @@ EventUpcasterChain eventUpcasterChain() {
 
 link:index.adoc[Index]
 
-link:05-05-TokenStores.adoc[← Previous: Token Stores]
+link:05-06-TokenStores.adoc[← Previous: Token Stores]
 
-link:05-07-Sagas.adoc[Next: Sagas →]
+link:05-08-Sagas.adoc[Next: Sagas →]

--- a/docs/modules/ROOT/pages/05-08-Sagas.adoc
+++ b/docs/modules/ROOT/pages/05-08-Sagas.adoc
@@ -4,9 +4,9 @@
 
 link:index.adoc[Index]
 
-link:05-06-EventUpcasting.adoc[← Previous: Event Upcasting]
+link:05-07-EventUpcasting.adoc[← Previous: Event Upcasting]
 
-link:05-08-ExceptionHandling.adoc[Next: Exception Handling →]
+link:05-09-ExceptionHandling.adoc[Next: Exception Handling →]
 
 '''
 
@@ -58,7 +58,7 @@ public class CardReturnSaga {
     }
 }
 ----
-<1> Necessary annotation, that this Saga is registered with field for serialization, if the serializer cannot access fields(see link:05-17-Serialization.adoc[Serialization])
+<1> Necessary annotation, that this Saga is registered with field for serialization, if the serializer cannot access fields(see link:05-18-Serialization.adoc[Serialization])
 <2> An application scoped bean is injected. It must be transient because of serialization
 <3> the application scoped bean is used to do some necessary task
 <4> the application scoped bean is used to do some necessary task
@@ -81,7 +81,7 @@ If you would like to use the JDBC Sagastore, you simply have to add the dependen
 </dependency>
 ----
 
-NOTE: The dependency quarkus-axon-transaction for transaction management is automatically added. For detailed information see link:05-13-Transaction.adoc[Transaction].
+NOTE: The dependency quarkus-axon-transaction for transaction management is automatically added. For detailed information see link:05-14-Transaction.adoc[Transaction].
 
 By default the database table is created on startup. If you don't want to create the table automatically, you can disable the creation.
 
@@ -117,6 +117,6 @@ include::includes/quarkus-axon-sagastore-jdbc.adoc[leveloffset=+1,opts=optional]
 
 link:index.adoc[Index]
 
-link:05-06-EventUpcasting.adoc[← Previous: Event Upcasting]
+link:05-07-EventUpcasting.adoc[← Previous: Event Upcasting]
 
-link:05-08-ExceptionHandling.adoc[Next: Exception Handling →]
+link:05-09-ExceptionHandling.adoc[Next: Exception Handling →]

--- a/docs/modules/ROOT/pages/05-09-ExceptionHandling.adoc
+++ b/docs/modules/ROOT/pages/05-09-ExceptionHandling.adoc
@@ -26,6 +26,6 @@ quarkus.axon.exception-handling.wrap-on-query-handler=false
 
 link:index.adoc[Index]
 
-link:05-07-Sagas.adoc[← Previous: Sagas]
+link:05-08-Sagas.adoc[← Previous: Sagas]
 
-link:05-09-CommandBus.adoc[Next: CommandBus →]
+link:05-10-CommandBus.adoc[Next: CommandBus →]

--- a/docs/modules/ROOT/pages/05-10-CommandBus.adoc
+++ b/docs/modules/ROOT/pages/05-10-CommandBus.adoc
@@ -50,6 +50,6 @@ public class MyCommandBusConfigurer implements CommandBusConfigurer {
 
 link:index.adoc[Index]
 
-link:05-08-ExceptionHandling.adoc[← Previous: Exception Handling]
+link:05-09-ExceptionHandling.adoc[← Previous: Exception Handling]
 
-link:05-10-CommandGateway.adoc[Next: Command Gateway →]
+link:05-11-CommandGateway.adoc[Next: Command Gateway →]

--- a/docs/modules/ROOT/pages/05-11-CommandGateway.adoc
+++ b/docs/modules/ROOT/pages/05-11-CommandGateway.adoc
@@ -55,6 +55,6 @@ public RetryScheduler retryScheduler() {
 
 link:index.adoc[Index]
 
-link:05-09-CommandBus.adoc[← Previous: Command Bus]
+link:05-10-CommandBus.adoc[← Previous: Command Bus]
 
-link:05-11-Interceptors.adoc[Next: Interceptors →]
+link:05-12-Interceptors.adoc[Next: Interceptors →]

--- a/docs/modules/ROOT/pages/05-12-Interceptors.adoc
+++ b/docs/modules/ROOT/pages/05-12-Interceptors.adoc
@@ -94,6 +94,6 @@ These interceptors are registered for each event processor.
 
 link:index.adoc[Index]
 
-link:05-08-ExceptionHandling.adoc[← Previous: Exception Handling]
+link:05-09-ExceptionHandling.adoc[← Previous: Exception Handling]
 
-link:05-12-InjectCdiBeans.adoc[Next: Inject CDI Beans into Message Handler Methods →]
+link:05-13-InjectCdiBeans.adoc[Next: Inject CDI Beans into Message Handler Methods →]

--- a/docs/modules/ROOT/pages/05-13-InjectCdiBeans.adoc
+++ b/docs/modules/ROOT/pages/05-13-InjectCdiBeans.adoc
@@ -23,6 +23,6 @@ void handle(MyCommand command, MyBean bean) {
 
 link:index.adoc[Index]
 
-link:05-11-Interceptors.adoc[← Previous: Interceptors]
+link:05-12-Interceptors.adoc[← Previous: Interceptors]
 
-link:05-13-Transaction.adoc[Next: Transaction →]
+link:05-14-Transaction.adoc[Next: Transaction →]

--- a/docs/modules/ROOT/pages/05-14-Transaction.adoc
+++ b/docs/modules/ROOT/pages/05-14-Transaction.adoc
@@ -19,6 +19,6 @@ It uses the quarkus transaction management configured into the axon framework.
 
 link:index.adoc[Index]
 
-link:05-12-InjectCdiBeans.adoc[← Previous: Inject CDI Beans into Message Handler Methods]
+link:05-13-InjectCdiBeans.adoc[← Previous: Inject CDI Beans into Message Handler Methods]
 
-link:05-14-Metrics.adoc[Next: Metrics →]
+link:05-15-Metrics.adoc[Next: Metrics →]

--- a/docs/modules/ROOT/pages/05-15-Metrics.adoc
+++ b/docs/modules/ROOT/pages/05-15-Metrics.adoc
@@ -30,6 +30,6 @@ include::includes/quarkus-axon-metrics.adoc[leveloffset=+1,opts=optional]
 
 link:index.adoc[Index]
 
-link:05-13-Transaction.adoc[← Previous: Transaction]
+link:05-14-Transaction.adoc[← Previous: Transaction]
 
-link:05-15-HealthChecks.adoc[Next: Health Checks →]
+link:05-16-HealthChecks.adoc[Next: Health Checks →]

--- a/docs/modules/ROOT/pages/05-16-HealthChecks.adoc
+++ b/docs/modules/ROOT/pages/05-16-HealthChecks.adoc
@@ -16,6 +16,6 @@ to false. Be aware that these settings are build-time settings. That means that 
 
 link:index.adoc[Index]
 
-link:05-14-Metrics.adoc[← Previous: Metrics]
+link:05-15-Metrics.adoc[← Previous: Metrics]
 
-link:05-16-AccessToAxonObjects.adoc[Next: Access To Axon Objects →]
+link:05-17-AccessToAxonObjects.adoc[Next: Access To Axon Objects →]

--- a/docs/modules/ROOT/pages/05-17-AccessToAxonObjects.adoc
+++ b/docs/modules/ROOT/pages/05-17-AccessToAxonObjects.adoc
@@ -16,6 +16,6 @@ you can simply inject it to your CDI bean. You can see example injections in lin
 
 link:index.adoc[Index]
 
-link:05-15-HealthChecks.adoc[← Previous: Health Checks]
+link:05-16-HealthChecks.adoc[← Previous: Health Checks]
 
-link:05-17-Serialization.adoc[Next: Serialization →]
+link:05-18-Serialization.adoc[Next: Serialization →]

--- a/docs/modules/ROOT/pages/05-18-Serialization.adoc
+++ b/docs/modules/ROOT/pages/05-18-Serialization.adoc
@@ -21,4 +21,4 @@ If your commands or queries or one of its classes in the object hierarchy doesn'
 
 link:index.adoc[Index]
 
-link:05-16-AccessToAxonObjects.adoc[← Previous: Access To Axon Objects]
+link:05-17-AccessToAxonObjects.adoc[← Previous: Access To Axon Objects]

--- a/integration-tests/src/test/java/at/meks/quarkiverse/axon/it/ApplicationTest.java
+++ b/integration-tests/src/test/java/at/meks/quarkiverse/axon/it/ApplicationTest.java
@@ -57,7 +57,7 @@ class ApplicationTest {
                 .pollInterval(Duration.ofMillis(100))
                 .atMost(Duration.ofSeconds(5))
                 .untilAsserted(() -> assertCurrentAmount(14));
-        assertAtLeastOneSnaptshotExists();
+        assertAtLeastOneSnapshotExists();
     }
 
     private void issueNewCard(@SuppressWarnings("SameParameterValue") int initialAmount) {
@@ -100,7 +100,7 @@ class ApplicationTest {
                 .body("id", CoreMatchers.equalTo(this.cardId), "currentAmount", CoreMatchers.equalTo(expectedAmount));
     }
 
-    private void assertAtLeastOneSnaptshotExists() {
+    private void assertAtLeastOneSnapshotExists() {
         Awaitility.await()
                 .pollInterval(Duration.ofMillis(500))
                 .atMost(Duration.ofSeconds(5))

--- a/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/model/Api.java
+++ b/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/model/Api.java
@@ -34,4 +34,9 @@ public class Api {
     public record CardReturnedEvent(String id) {
     }
 
+    public record AddPersonalInformationCommand(@TargetAggregateIdentifier String id, String personName) {
+    }
+
+    public record PersonalInformationAddedEvent(String id, String personName) {
+    }
 }

--- a/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/model/Giftcard.java
+++ b/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/model/Giftcard.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateMember;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
@@ -22,6 +23,9 @@ public class Giftcard {
     private String id;
     private int currentAmount;
     private final List<Integer> cardRedemptions = new ArrayList<>();
+
+    @AggregateMember
+    private final PersonalInformation personalInformation = new PersonalInformation();
 
     @SuppressWarnings("unused")
     Giftcard() {

--- a/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/model/PersonalInformation.java
+++ b/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/model/PersonalInformation.java
@@ -1,0 +1,24 @@
+package at.meks.quarkiverse.axon.shared.model;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.modelling.command.AggregateLifecycle;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class PersonalInformation {
+
+    String personName;
+
+    @CommandHandler
+    void handle(Api.AddPersonalInformationCommand command) {
+        AggregateLifecycle.apply(new Api.PersonalInformationAddedEvent(command.id(), command.personName()));
+    }
+
+    @EventSourcingHandler
+    void handle(Api.PersonalInformationAddedEvent event) {
+        this.personName = event.personName();
+    }
+
+}

--- a/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardQueryHandler.java
+++ b/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardQueryHandler.java
@@ -29,6 +29,11 @@ public class GiftcardQueryHandler {
     }
 
     @EventHandler
+    void handle(Api.PersonalInformationAddedEvent event) {
+        giftcards.get(event.id()).setPersonName(event.personName());
+    }
+
+    @EventHandler
     void handle(Api.CardRedeemedEvent event) {
         giftcards.get(event.id()).redeem(event.amount());
     }

--- a/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardView.java
+++ b/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardView.java
@@ -9,6 +9,7 @@ public class GiftcardView {
     private final String id;
 
     private int currentAmount;
+    private String personName;
 
     @SuppressWarnings("unused")
     GiftcardView() {
@@ -19,6 +20,12 @@ public class GiftcardView {
     public GiftcardView(String id, int currentAmount) {
         this.id = id;
         this.currentAmount = currentAmount;
+    }
+
+    public GiftcardView(String id, int currentAmount, String personName) {
+        this.id = id;
+        this.currentAmount = currentAmount;
+        this.personName = personName;
     }
 
     void redeem(int amount) {
@@ -32,4 +39,9 @@ public class GiftcardView {
     public void undoLastRedemption(int amount) {
         currentAmount += amount;
     }
+
+    public void setPersonName(String personName) {
+        this.personName = personName;
+    }
+
 }

--- a/shared/test/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
+++ b/shared/test/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
@@ -89,6 +89,7 @@ public class JavaArchiveTest {
         prepareForTest();
         var cardId = UUID.randomUUID().toString();
         commandGateway.sendAndWait(new Api.IssueCardCommand(cardId, 10));
+        commandGateway.sendAndWait(new Api.AddPersonalInformationCommand(cardId, "Bruce Wayne"));
         await().atMost(Duration.ofSeconds(10))
                 .pollDelay(Duration.ZERO)
                 .untilAsserted(
@@ -105,7 +106,7 @@ public class JavaArchiveTest {
         assertThat(queryResult)
                 .succeedsWithin(Duration.ofSeconds(1))
                 .usingRecursiveComparison()
-                .isEqualTo(new GiftcardView(cardId, 9));
+                .isEqualTo(new GiftcardView(cardId, 9, "Bruce Wayne"));
 
         assertThatAllEventHandlerClassesWereInformed();
 


### PR DESCRIPTION
It is now possible to use Multi-Entity Aggregates with CommandHandlers in AggregateMembers. 
Before an exception was thrown, because all Classes, containing CommandHandler had to be a Root Aggregate or a CDI Bean.

The documentation was extended to explain how the registration of command handlers works.