### PR TITLE
upgrade AxonFramework to 4.11.1

### DIFF
--- a/docs/modules/ROOT/pages/02-CompatibilityMatrix.adoc
+++ b/docs/modules/ROOT/pages/02-CompatibilityMatrix.adoc
@@ -4,6 +4,7 @@ The latest LTS is not supported anymore because of build issues. The current ver
 |===
 | Extension Version | Quarkus | Axon framework | Notes
 
+| 0.1.0-RC12 | 3.19.2 | 4.11.1 | not compatible with quarkus < 3.18
 | 0.1.0-RC11 | 3.18.3 | 4.10.4 | not compatible with quarkus < 3.18
 | 0.1.0-RC10 | 3.18.3 | 4.10.4 | not compatible with quarkus < 3.18
 | 0.1.0-RC9  | 3.18.1 | 4.10.4 | not compatible with quarkus < 3.18

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-bom</artifactId>
-                <version>4.10.4</version>
+                <version>4.11.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -81,13 +81,20 @@
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-messaging</artifactId>
                 <!-- maven doesn't use the version of the imported axon-bom. Better than duplicated exclusion? -->
-                <version>4.10.3</version>
+                <version>4.11.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.thoughtworks.xstream</groupId>
                         <artifactId>xstream</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <!-- The dependency is necessary, because the axon framework and the axon server connector use different
+                 major versions. Axoniq said that the major version 4 is backward compatible to the version 3. -->
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>4.29.3</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
fixed the compile errors because of the different used major versions of protobuf-java.
The proposed solution of Axoniq is to use the most current major version 4 in the
extension.