### PR TITLE
#214 Startup fails at (Query/Event/Command)Handler if method argument…

### DIFF
--- a/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/AxonExtensionProcessor.java
+++ b/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/AxonExtensionProcessor.java
@@ -234,6 +234,7 @@ class AxonExtensionProcessor {
             BeanArchiveIndexBuildItem beanArchiveIndex,
             BuildProducer<InjectableBeanBuildItem> beanProducer) {
         injectableBeanClasses(beanArchiveIndex)
+                .filter(clz -> beanArchiveIndex.getImmutableIndex().getClassByName(clz.getName()) != null)
                 .map(InjectableBeanBuildItem::new)
                 .forEach(item -> {
                     Log.infof("found injectable beans: %s", item.itemClass());

--- a/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardInMemoryHistory.java
+++ b/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/projection/GiftcardInMemoryHistory.java
@@ -5,8 +5,7 @@ import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
-import org.axonframework.eventhandling.EventHandler;
-import org.axonframework.eventhandling.ResetHandler;
+import org.axonframework.eventhandling.*;
 
 import at.meks.quarkiverse.axon.shared.model.Api;
 import io.quarkus.logging.Log;
@@ -18,7 +17,15 @@ public class GiftcardInMemoryHistory {
     private boolean cardIssuedEventWasHandled = false;
 
     @EventHandler
-    void handle(Api.CardIssuedEvent event) {
+    void handle(Api.CardIssuedEvent event, @SequenceNumber long sequenceNumber) {
+        Log.debugf("handling event %s", event);
+        cardIssuedEventWasHandled = true;
+        history.add(event);
+    }
+
+    @EventHandler
+    void handle(Api.CardIssuedEvent event, TrackingToken trackingToken, @SequenceNumber Long sequenceNumber,
+            ReplayStatus replayStatus) {
         Log.debugf("handling event %s", event);
         cardIssuedEventWasHandled = true;
         history.add(event);


### PR DESCRIPTION
… is not CDI Bean

Startup doesn't fail if handler methods contain arguments, which are no CDI beans. This is necessary because the Axon-Framework also supports injections of some classes.