### PR TITLE
Hotfix: Latest Version of Axon Server doesn't start anymore without error

### DIFF
--- a/eventstores/axon-server/deployment/src/main/java/at/meks/quarkiverse/axon/server/deployment/AxonServerProcessor.java
+++ b/eventstores/axon-server/deployment/src/main/java/at/meks/quarkiverse/axon/server/deployment/AxonServerProcessor.java
@@ -45,7 +45,7 @@ public class AxonServerProcessor {
         if (!buildTimeConfig.devServices().enabled()) {
             return null;
         }
-        DockerImageName dockerImageName = DockerImageName.parse("axoniq/axonserver");
+        DockerImageName dockerImageName = DockerImageName.parse("axoniq/axonserver").withTag("2025.0.2");
         GenericContainer<?> container = new GenericContainer<>(dockerImageName)
                 .withExposedPorts(8024, 8124, 8224)
                 .waitingFor(Wait.forLogMessage(".*default: context default created.*", 1))


### PR DESCRIPTION
Fallback to latest working version 2025.0.2.