### PR TITLE
255-Support for Injecting ConfigMapping into Message-Handler-Methods

### DIFF
--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
@@ -21,9 +21,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import at.meks.quarkiverse.axon.runtime.conf.AxonConfiguration;
 import at.meks.quarkiverse.axon.shared.TestModelConfig;
+import io.quarkus.logging.Log;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class InjectableCdiBeansTest {
@@ -73,16 +74,8 @@ public class InjectableCdiBeansTest {
     @ApplicationScoped
     static class InjectableCdiBeanForAggregate {
 
-        @Inject
-        AxonConfiguration axonConfiguration;
-
-        @Inject
-        TestModelConfig testModelConfig;
-
         void doSomething() {
             logger.debug("do something");
-            System.out.printf("postConstruct; AxonApplicationName: %s%n", axonConfiguration.axonApplicationName());
-            System.out.printf("postConstruct; TestModelConfigValue: %s%n", testModelConfig.value());
         }
     }
 
@@ -117,7 +110,8 @@ public class InjectableCdiBeansTest {
     static class DomainServiceCommandHandlerUsingCdiBean {
 
         @CommandHandler
-        void handle(CommandHandledByDomainService command, InjectableCdiBeanForDomainService bean) {
+        void handle(CommandHandledByDomainService command, InjectableCdiBeanForDomainService bean,
+                TestModelConfig testModelConfig) {
             bean.doSomething();
         }
     }
@@ -134,7 +128,7 @@ public class InjectableCdiBeansTest {
         }
 
         @CommandHandler
-        AggregateCommandHandlerUsingCdiBean(CommandHandledByAggregate command, InjectableCdiBeanForAggregate bean) {
+        AggregateCommandHandlerUsingCdiBean(CommandHandledByAggregate command, InjectableCdiBeanForAggregate bean, TestModelConfig testModelConfig) {
             bean.doSomething();
         }
 
@@ -149,7 +143,7 @@ public class InjectableCdiBeansTest {
     static class EventHandlerUsingCdiBean {
 
         @EventHandler
-        void on(MyEvent event, InjectableCdiBeanForEventHandler bean) {
+        void on(MyEvent event, InjectableCdiBeanForEventHandler bean, TestModelConfig testModelConfig) {
             bean.doSomething();
         }
     }
@@ -159,7 +153,7 @@ public class InjectableCdiBeansTest {
     static class QueryHandlerUsingCdiBean {
 
         @QueryHandler
-        boolean on(MyQuery query, InjectableCdiBeanForQueryHandler bean) {
+        boolean on(MyQuery query, InjectableCdiBeanForQueryHandler bean, TestModelConfig testModelConfig) {
             bean.doSomething();
             return true;
         }

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
+import at.meks.quarkiverse.axon.runtime.conf.AxonConfiguration;
+import at.meks.quarkiverse.axon.shared.TestModelConfig;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class InjectableCdiBeansTest {
@@ -71,8 +73,16 @@ public class InjectableCdiBeansTest {
     @ApplicationScoped
     static class InjectableCdiBeanForAggregate {
 
+        @Inject
+        AxonConfiguration axonConfiguration;
+
+        @Inject
+        TestModelConfig testModelConfig;
+
         void doSomething() {
             logger.debug("do something");
+            System.out.printf("postConstruct; AxonApplicationName: %s%n", axonConfiguration.axonApplicationName());
+            System.out.printf("postConstruct; TestModelConfigValue: %s%n", testModelConfig.value());
         }
     }
 

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/InjectableCdiBeansTest.java
@@ -21,10 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import at.meks.quarkiverse.axon.shared.TestModelConfig;
-import io.quarkus.logging.Log;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class InjectableCdiBeansTest {
@@ -128,7 +126,8 @@ public class InjectableCdiBeansTest {
         }
 
         @CommandHandler
-        AggregateCommandHandlerUsingCdiBean(CommandHandledByAggregate command, InjectableCdiBeanForAggregate bean, TestModelConfig testModelConfig) {
+        AggregateCommandHandlerUsingCdiBean(CommandHandledByAggregate command, InjectableCdiBeanForAggregate bean,
+                TestModelConfig testModelConfig) {
             bean.doSomething();
         }
 

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/AxonInitializationRecorder.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/AxonInitializationRecorder.java
@@ -3,8 +3,12 @@ package at.meks.quarkiverse.axon.runtime;
 import java.util.Collection;
 import java.util.Set;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.SmallRyeConfig;
 
 @Recorder
 public class AxonInitializationRecorder {
@@ -23,7 +27,15 @@ public class AxonInitializationRecorder {
                 .forEach(axonExtension::addEventhandlerForRegistration);
         axonExtension.setSagaClasses(sagaEventhandlerClasses);
         injectableBeanClasses
-                .forEach(clazz -> axonExtension.addInjectableBean(clazz, beanContainer.beanInstance(clazz)));
+                .forEach(clazz -> axonExtension.addInjectableBean(clazz, getBean(beanContainer, clazz)));
         axonExtension.init();
+    }
+
+    private static Object getBean(BeanContainer beanContainer, Class<?> clazz) {
+        if (clazz.isAnnotationPresent(ConfigMapping.class)) {
+            SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
+            return config.getConfigMapping(clazz);
+        }
+        return beanContainer.beanInstance(clazz);
     }
 }

--- a/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/TestModelConfig.java
+++ b/shared/test/model/src/main/java/at/meks/quarkiverse/axon/shared/TestModelConfig.java
@@ -1,0 +1,11 @@
+package at.meks.quarkiverse.axon.shared;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "test.model")
+public interface TestModelConfig {
+
+    @WithDefault("defaultValue")
+    String value();
+}


### PR DESCRIPTION
An exception occurred when an interface, annotated with ConfigMapping was used as method argument for a message handler method(CommandHanlder, EventHandler, QueryHandler,..).

The reason was that the bean container wasn't able to resolve this interface as a bean.

This error was reported with the issue #255 