### PR TITLE
Add virtual thread support for pooled event processors

### DIFF
--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/PooledProcessorTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/PooledProcessorTest.java
@@ -3,8 +3,11 @@ package at.meks.quarkiverse.axon.deployment.eventprocessors.pooled;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.axonframework.messaging.eventhandling.processing.EventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
 
@@ -35,6 +38,16 @@ public abstract class PooledProcessorTest extends JavaArchiveTest {
     protected String[] expectedEventProcessorNames() {
         return new String[] { "GiftCardInMemory", "at.meks.quarkiverse.axon.shared.projection",
                 "at.meks.quarkiverse.axon.shared.projection2" };
+    }
+
+    protected boolean workerExecutorUsesVirtualThreads(PooledStreamingEventProcessor processor) {
+        try {
+            ScheduledExecutorService workerExecutor = (ScheduledExecutorService) FieldUtils.readField(
+                    processor, "workerExecutor", true);
+            return workerExecutor.submit(() -> Thread.currentThread().isVirtual()).get();
+        } catch (IllegalAccessException | InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/VirtualThreadsOverrideTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/VirtualThreadsOverrideTest.java
@@ -1,0 +1,30 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors.pooled;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class VirtualThreadsOverrideTest extends PooledProcessorTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = application()
+            .withConfigurationResource("eventprocessors/pooled/virtualThreadsOverride.properties");
+
+    @Override
+    protected void assertPooledConfigurations(Map<String, PooledStreamingEventProcessor> processors) {
+        assertThat(workerExecutorUsesVirtualThreads(processors.get("GiftCardInMemory")))
+                .describedAs("named processor should override default virtual-thread setting")
+                .isFalse();
+        assertThat(workerExecutorUsesVirtualThreads(processors.get("at.meks.quarkiverse.axon.shared.projection")))
+                .describedAs("unnamed processor should inherit default virtual-thread setting")
+                .isTrue();
+        assertThat(workerExecutorUsesVirtualThreads(processors.get("at.meks.quarkiverse.axon.shared.projection2")))
+                .describedAs("unnamed processor should inherit default virtual-thread setting")
+                .isTrue();
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/VirtualThreadsTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/VirtualThreadsTest.java
@@ -1,0 +1,24 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors.pooled;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class VirtualThreadsTest extends PooledProcessorTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = application()
+            .withConfigurationResource("eventprocessors/pooled/virtualThreads.properties");
+
+    @Override
+    protected void assertPooledConfigurations(Map<String, PooledStreamingEventProcessor> processors) {
+        processors.forEach((name, processor) -> assertThat(workerExecutorUsesVirtualThreads(processor))
+                .describedAs("worker executor for " + name + " should use virtual threads")
+                .isTrue());
+    }
+}

--- a/core/deployment/src/test/resources/eventprocessors/pooled/virtualThreads.properties
+++ b/core/deployment/src/test/resources/eventprocessors/pooled/virtualThreads.properties
@@ -1,0 +1,5 @@
+quarkus.axon.event-processing.default-event-processing-type=pooled
+quarkus.axon.pooledprocessor.initial-segments=1
+quarkus.axon.pooledprocessor.worker-thread-pool-size=1
+quarkus.axon.pooledprocessor.use-virtual-threads=true
+quarkus.axon.pooledprocessor.namespaces=GiftCardInMemory

--- a/core/deployment/src/test/resources/eventprocessors/pooled/virtualThreadsOverride.properties
+++ b/core/deployment/src/test/resources/eventprocessors/pooled/virtualThreadsOverride.properties
@@ -1,0 +1,5 @@
+quarkus.axon.event-processing.default-event-processing-type=pooled
+quarkus.axon.pooledprocessor.initial-segments=1
+quarkus.axon.pooledprocessor.worker-thread-pool-size=1
+quarkus.axon.pooledprocessor.use-virtual-threads=true
+quarkus.axon.pooledprocessor.GiftCardInMemory.use-virtual-threads=false

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/PooledProcessorConf.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/PooledProcessorConf.java
@@ -41,6 +41,11 @@ public interface PooledProcessorConf {
          */
         Optional<Integer> workerThreadPoolSize();
 
+        /**
+         * If true, virtual threads are used for the worker executor of this processor.
+         */
+        Optional<Boolean> useVirtualThreads();
+
     }
 
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/eventprocessors/PooledEventProcessingConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/eventprocessors/PooledEventProcessingConfigurer.java
@@ -3,6 +3,8 @@ package at.meks.quarkiverse.axon.runtime.defaults.eventprocessors;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 
 import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -149,10 +151,23 @@ public class PooledEventProcessingConfigurer extends AbstractEventProcessingConf
                 .or(defaultConfig::workerThreadPoolSize)
                 .filter(poolSize -> poolSize > 0)
                 .ifPresent(size -> pooledStreamingEventProcessorConfiguration.workerExecutor(
-                        newScheduledThreadPool(size, new AxonThreadFactory(
-                                "Worker - " + pooledStreamingEventProcessorConfiguration.processorName()))));
+                        createWorkerExecutor(size, pooledStreamingEventProcessorConfiguration.processorName(),
+                                namedConfig, defaultConfig)));
         // TODO configure coordinatorExecutor?
         return pooledStreamingEventProcessorConfiguration;
+    }
+
+    private static ScheduledExecutorService createWorkerExecutor(int poolSize, String processorName,
+            ConfigOfOneProcessor namedConfig, ConfigOfOneProcessor defaultConfig) {
+        ThreadFactory threadFactory = shouldUseVirtualThreads(namedConfig, defaultConfig)
+                ? Thread.ofVirtual().name("Worker - " + processorName + "-", 0).factory()
+                : new AxonThreadFactory("Worker - " + processorName);
+        return newScheduledThreadPool(poolSize, threadFactory);
+    }
+
+    private static boolean shouldUseVirtualThreads(ConfigOfOneProcessor namedConfig,
+            ConfigOfOneProcessor defaultConfig) {
+        return namedConfig.useVirtualThreads().or(defaultConfig::useVirtualThreads).orElse(false);
     }
 
     private static boolean shouldUseInMemoryTokenStore(ConfigOfOneProcessor configOfOneProcessor,

--- a/docs/modules/ROOT/pages/05-06-EventProcessors.adoc
+++ b/docs/modules/ROOT/pages/05-06-EventProcessors.adoc
@@ -46,6 +46,19 @@ quarkus.axon.pooledprocessor.processor1.initial-position=head
 quarkus.axon.pooledprocessor.processor2.batch-size=10
 ----
 
+=== Virtual Threads
+
+Pooled event processors can use virtual threads for their worker executor.
+This is opt-in per processor, or on the default pooled processor configuration.
+Virtual threads are useful for I/O-bound event handlers, for example projections that write to a database.
+
+[source,properties]
+----
+quarkus.axon.pooledprocessor.worker-thread-pool-size=4
+quarkus.axon.pooledprocessor.use-virtual-threads=true
+quarkus.axon.pooledprocessor.processor1.use-virtual-threads=false
+----
+
 === Random Processor Name
 
 For this both processor types, you can define that the processor should be registered with a random name. This is useful, if you want to hold a In-Memory projection. Using a random processor name has the impact, that on startup all events are processed from the initial position.

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor.adoc
@@ -163,6 +163,32 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-use-virtual-threads]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-use-virtual-threads[`quarkus.axon.pooledprocessor.use-virtual-threads`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.axon.pooledprocessor."processor-name".use-virtual-threads`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor."processor-name".use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If true, virtual threads are used for the worker executor of this processor.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-processing-groups]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-processing-groups[`quarkus.axon.pooledprocessor.processing-groups`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.pooledprocessor.processing-groups+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-pooled-eventprocessor_quarkus.axon.adoc
@@ -163,6 +163,32 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-use-virtual-threads]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-use-virtual-threads[`quarkus.axon.pooledprocessor.use-virtual-threads`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.axon.pooledprocessor."processor-name".use-virtual-threads`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor."processor-name".use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If true, virtual threads are used for the worker executor of this processor.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-processing-groups]] [.property-path]##link:#quarkus-axon-pooled-eventprocessor_quarkus-axon-pooledprocessor-processing-groups[`quarkus.axon.pooledprocessor.processing-groups`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.pooledprocessor.processing-groups+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -726,6 +726,32 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-axon_quarkus-axon-pooledprocessor-use-virtual-threads]] [.property-path]##link:#quarkus-axon_quarkus-axon-pooledprocessor-use-virtual-threads[`+++quarkus.axon.pooledprocessor.use-virtual-threads+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.axon.pooledprocessor."processor-name".use-virtual-threads+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor."processor-name".use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If true, virtual threads are used for the worker executor of this processor.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 |===
 
 ifndef::no-duration-note[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -726,6 +726,32 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-axon_quarkus-axon-pooledprocessor-use-virtual-threads]] [.property-path]##link:#quarkus-axon_quarkus-axon-pooledprocessor-use-virtual-threads[`+++quarkus.axon.pooledprocessor.use-virtual-threads+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor.use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.axon.pooledprocessor."processor-name".use-virtual-threads+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.pooledprocessor."processor-name".use-virtual-threads+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If true, virtual threads are used for the worker executor of this processor.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_POOLEDPROCESSOR_USE_VIRTUAL_THREADS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 |===
 
 ifndef::no-duration-note[]

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>3.37.1</quarkus.version>


### PR DESCRIPTION
## Summary

Adds opt-in virtual thread support for pooled event processor worker executors.

Fixes #38

## Changes

- Bumps the project compiler release from Java 17 to Java 21, matching the Axon 5.1.x baseline.
- Adds `quarkus.axon.pooledprocessor.use-virtual-threads`.
- Supports the setting on both the default pooled processor configuration and named pooled processor configurations.
- Wires pooled processor worker executors to use `Thread.ofVirtual()` when enabled.
- Keeps the existing Axon platform-thread executor behavior when the setting is absent or `false`.
- Adds tests for:
  - all pooled processors inheriting virtual thread usage from the default config
  - a named processor overriding the default virtual-thread setting
- Updates event processor docs and generated-style config references.

## Validation

Ran:

```bash
mvn -pl core/deployment -am '-Dtest=VirtualThreadsTest,VirtualThreadsOverrideTest' '-Dsurefire.failIfNoSpecifiedTests=false' test
```

Result: build successful, both tests passed.

## Risk / Clarifications

- This intentionally scopes support to pooled event processor worker executors only.
- Retry scheduler virtual-thread support is not included.
- Coordinator executor virtual-thread support is not included.
- `worker-thread-pool-size` remains meaningful: it still controls the scheduled worker executor pool size, even when the executor uses virtual threads.
- Native-image behaviour was not separately tested in this change.
- The Java 21 compiler baseline is required because the implementation uses the Java 21 virtual thread API directly.