### PR TITLE
Added configuration to disable update check and usage data reporting.

### DIFF
--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/DisableUpdateCheckTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/DisableUpdateCheckTest.java
@@ -1,0 +1,35 @@
+package at.meks.quarkiverse.axon.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import jakarta.inject.Inject;
+
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.update.configuration.UsagePropertyProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.runtime.defaults.DisableUpdateCheck;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class DisableUpdateCheckTest {
+
+    static {
+        System.setProperty("axoniq.usage.force-test-environment", "true");
+    }
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(JavaArchiveTest::javaArchiveBase)
+            .withConfigurationResource("disableupdatecheck.properties");
+
+    @Inject
+    Configuration configuration;
+
+    @Test
+    void testDisabledUpdateCheck() {
+        var usagePropertyProvider = configuration.getComponent(UsagePropertyProvider.class);
+        assertInstanceOf(DisableUpdateCheck.class, usagePropertyProvider);
+    }
+}

--- a/core/deployment/src/test/resources/disableupdatecheck.properties
+++ b/core/deployment/src/test/resources/disableupdatecheck.properties
@@ -1,0 +1,1 @@
+quarkus.axon.update-check.disabled=true

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
@@ -20,6 +20,13 @@ public interface AxonConfiguration {
     String axonApplicationName();
 
     /**
+     * configuration to disable update check and usage data reporting
+     */
+    @WithName("update-check.disabled")
+    @WithDefault("false")
+    boolean updateCheckDisabled();
+
+    /**
      * additional configuration for live reloading for axon.
      */
     LiveReloadConfig liveReload();

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
@@ -18,6 +18,7 @@ import org.axonframework.messaging.eventhandling.configuration.EventHandlingComp
 import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 //import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
+import org.axonframework.update.configuration.UsagePropertyProvider;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +93,9 @@ public class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
                             axonConverterProducer.createMessageConverter()));
                     registry.registerComponent(EventConverter.class, c -> new DelegatingEventConverter(
                             axonConverterProducer.createEventConverter()));
+                    if (axonConfiguration.updateCheckDisabled()) {
+                        registry.registerComponent(UsagePropertyProvider.class, c -> new DisableUpdateCheck());
+                    }
                 });
         configureTracing(configurer);
         eventstoreConfigurer.configure(configurer);

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DisableUpdateCheck.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DisableUpdateCheck.java
@@ -1,0 +1,21 @@
+package at.meks.quarkiverse.axon.runtime.defaults;
+
+import org.axonframework.update.configuration.UsagePropertyProvider;
+import org.jspecify.annotations.Nullable;
+
+public class DisableUpdateCheck implements UsagePropertyProvider {
+    @Override
+    public Boolean getDisabled() {
+        return true;
+    }
+
+    @Override
+    public @Nullable String getUrl() {
+        return "";
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -225,6 +225,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++quarkus-axon+++`
 
+a| [[quarkus-axon_quarkus-axon-update-check-disabled]] [.property-path]##link:#quarkus-axon_quarkus-axon-update-check-disabled[`+++quarkus.axon.update-check.disabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.update-check.disabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+configuration to disable update check and usage data reporting
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_UPDATE_CHECK_DISABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_UPDATE_CHECK_DISABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit]] [.property-path]##link:#quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit[`+++quarkus.axon.live-reload.shutdown.wait-duration.unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.live-reload.shutdown.wait-duration.unit+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -225,6 +225,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++quarkus-axon+++`
 
+a| [[quarkus-axon_quarkus-axon-update-check-disabled]] [.property-path]##link:#quarkus-axon_quarkus-axon-update-check-disabled[`+++quarkus.axon.update-check.disabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.update-check.disabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+configuration to disable update check and usage data reporting
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_UPDATE_CHECK_DISABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_UPDATE_CHECK_DISABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit]] [.property-path]##link:#quarkus-axon_quarkus-axon-live-reload-shutdown-wait-duration-unit[`+++quarkus.axon.live-reload.shutdown.wait-duration.unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.live-reload.shutdown.wait-duration.unit+++[]


### PR DESCRIPTION
Similar to [direct configuration of the framework](https://docs.axoniq.io/axon-framework-update-checker/#_what_does_the_update_checker_do), provides a property `quarkus.axon.update-check.disabled`. 
If set to `true` the update check and usage data reporting will be disabled.
