### PR TITLE
Provide @IdType annotation and register entities accordingly.

### DIFF
--- a/Axoniq-Framework-5_1-migration-guide.adoc
+++ b/Axoniq-Framework-5_1-migration-guide.adoc
@@ -22,3 +22,6 @@
 * QuarkusAggregateConfigurer: named to QuarkusEntityConfigurer, because name in AxonFramework changed to Entity
 * Snapshots are not supported anymore, except for AxonServer and InMemoryEventStorageEngine
 * migrate Snapshot configuration to Annotations
+* Aggregates -> Entities
+** The ID is not annotated any more, but we have to know it's type for registering the Entity.
+If the entity has an ID that is not if type `String`, annotate the Entity with `@IdType(YourIdType.class)`

--- a/Axoniq-Framework-5_1-migration-guide.adoc
+++ b/Axoniq-Framework-5_1-migration-guide.adoc
@@ -24,4 +24,4 @@
 * migrate Snapshot configuration to Annotations
 * Aggregates -> Entities
 ** The ID is not annotated any more, but we have to know it's type for registering the Entity.
-If the entity has an ID that is not if type `String`, annotate the Entity with `@IdType(YourIdType.class)`
+If the entity has an ID that is not of type `String`, annotate the Entity with `@IdType(YourIdType.class)`

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -119,6 +119,11 @@
                 <artifactId>quarkus-axon-tracing-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>at.meks.quarkiverse.axonframework-extension</groupId>
+                <artifactId>quarkus-axon-annotations</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/core/annotations/pom.xml
+++ b/core/annotations/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>at.meks.quarkiverse.axonframework-extension</groupId>
+        <artifactId>quarkus-axon-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-axon-annotations</artifactId>
+    <name>Quarkus Axon - Annotations</name>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/core/annotations/src/main/java/at/meks/quarkiverse/axon/annotations/IdType.java
+++ b/core/annotations/src/main/java/at/meks/quarkiverse/axon/annotations/IdType.java
@@ -1,0 +1,21 @@
+package at.meks.quarkiverse.axon.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Define the ID class for the EventSourcedEntity.
+ * This annotation is only necessary, if the ID is not of type String.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface IdType {
+
+    /**
+     * The class of the ID
+     */
+    Class<?> value();
+
+}

--- a/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/AxonExtensionProcessor.java
+++ b/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/AxonExtensionProcessor.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 import at.meks.quarkiverse.axon.runtime.AxonExtension;
 import at.meks.quarkiverse.axon.runtime.AxonInitializationRecorder;
+import at.meks.quarkiverse.axon.runtime.EventSourcedEntityDefinition;
 import at.meks.quarkiverse.axon.runtime.conf.ComponentDiscoveryConfiguration;
 import at.meks.quarkiverse.axon.runtime.defaults.*;
 import at.meks.quarkiverse.axon.runtime.defaults.eventprocessors.PooledEventProcessingConfigurer;
@@ -92,7 +93,7 @@ class AxonExtensionProcessor {
             List<InjectableBeanBuildItem> injectableBeanBuildItems,
             BeanContainerBuildItem beanContainerBuildItem, ComponentDiscoveryConfiguration discoveryConfiguration) {
 
-        Set<Class<?>> eventSourcedEntityClasses = classes(eventSourcedEntityBeanBuildItems, "event sourced entities",
+        Set<EventSourcedEntityDefinition> eventSourcedEntityClasses = eventSourcedClasses(eventSourcedEntityBeanBuildItems,
                 discoveryConfiguration.eventSourcedEntities());
         Set<Class<?>> eventhandlerClasses = classes(eventhandlerBeanBuildItems, "eventhandler",
                 discoveryConfiguration.eventHandlers());

--- a/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/ClassDiscovery.java
+++ b/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/ClassDiscovery.java
@@ -14,6 +14,7 @@ import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.queryhandling.annotation.QueryHandler;
 import org.jboss.jandex.*;
 
+import at.meks.quarkiverse.axon.runtime.EventSourcedEntityDefinition;
 import at.meks.quarkiverse.axon.runtime.conf.ComponentDiscoveryConfiguration;
 import at.meks.quarkiverse.axon.runtime.conf.ComponentDiscoveryConfiguration.ComponentDiscovery;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
@@ -38,6 +39,23 @@ class ClassDiscovery {
                 .collect(Collectors.toSet());
         axonClasses.forEach(clz -> Log.infof("Register " + objectType + " %s", clz));
         return axonClasses;
+    }
+
+    static Set<EventSourcedEntityDefinition> eventSourcedClasses(List<EventSourcedEntityBeanBuildItem> axonClassBuildItems,
+            ComponentDiscovery discovery) {
+        if (!discovery.enabled()) {
+            return Collections.emptySet();
+        }
+
+        Set<EventSourcedEntityDefinition> entityDefinitions = axonClassBuildItems.stream()
+                .filter(buildItem -> shouldBeDiscovered(buildItem.itemClass(), discovery))
+                .map(buildItem -> new EventSourcedEntityDefinition(buildItem.itemClass(), buildItem.getIdClass()))
+                .collect(Collectors.toSet());
+
+        entityDefinitions.forEach(ed -> Log.infof("Register event sourced entity %s with idClass", ed.entityClass(),
+                ed.idClass()));
+        return entityDefinitions;
+
     }
 
     private static boolean shouldBeDiscovered(Class<?> clazz, ComponentDiscovery discovery) {

--- a/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/EventSourcedEntityBeanBuildItem.java
+++ b/core/deployment/src/main/java/at/meks/quarkiverse/axon/deployment/EventSourcedEntityBeanBuildItem.java
@@ -1,13 +1,28 @@
 package at.meks.quarkiverse.axon.deployment;
 
+import java.util.Arrays;
+import java.util.Optional;
+
+import at.meks.quarkiverse.axon.annotations.IdType;
 import io.quarkus.builder.item.MultiBuildItem;
 
 public final class EventSourcedEntityBeanBuildItem extends MultiBuildItem implements ClassProvider {
 
     private final Class<?> entityClass;
+    private final Class<?> idClass;
 
     EventSourcedEntityBeanBuildItem(Class<?> entityClass) {
         this.entityClass = entityClass;
+        this.idClass = determineIdClass(entityClass);
+    }
+
+    private Class<?> determineIdClass(Class<?> entityClass) {
+        Optional<Class<?>> idType = Arrays.stream(entityClass.getAnnotationsByType(IdType.class)).findFirst().map(
+                IdType::value);
+        if (idType.isPresent()) {
+            return idType.get();
+        }
+        return String.class;
     }
 
     @Override
@@ -15,4 +30,7 @@ public final class EventSourcedEntityBeanBuildItem extends MultiBuildItem implem
         return entityClass;
     }
 
+    public Class<?> getIdClass() {
+        return idClass;
+    }
 }

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/EvaluateIdTypeAnnotationTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/EvaluateIdTypeAnnotationTest.java
@@ -1,0 +1,41 @@
+package at.meks.quarkiverse.axon.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import at.meks.quarkiverse.axon.annotations.IdType;
+import at.meks.quarkiverse.axon.runtime.defaults.DefaultEventSourceEntityConfigurer;
+
+class EvaluateIdTypeAnnotationTest {
+
+    DefaultEventSourceEntityConfigurer eventSourceEntityConfigurer = new DefaultEventSourceEntityConfigurer();
+
+    public static Stream<Arguments> testIdTypeAnnotation() {
+        return Stream.of(Arguments.of(EntityWithDefaults.class, String.class),
+                Arguments.of(EntityWithLongId.class, Long.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIdTypeAnnotation(Class<?> entityClass, Class<?> expectedIdClass) {
+        var entity = eventSourceEntityConfigurer.createConfigurer(entityClass);
+        assertEquals(expectedIdClass, entity.idType());
+    }
+
+    @EventSourcedEntity
+    @IdType(Long.class)
+    private final class EntityWithLongId {
+
+    }
+
+    @EventSourcedEntity
+    private final class EntityWithDefaults {
+
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/EventSourcedEntityBeanBuildItemTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/EventSourcedEntityBeanBuildItemTest.java
@@ -10,11 +10,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import at.meks.quarkiverse.axon.annotations.IdType;
-import at.meks.quarkiverse.axon.runtime.defaults.DefaultEventSourceEntityConfigurer;
 
-class EvaluateIdTypeAnnotationTest {
-
-    DefaultEventSourceEntityConfigurer eventSourceEntityConfigurer = new DefaultEventSourceEntityConfigurer();
+class EventSourcedEntityBeanBuildItemTest {
 
     public static Stream<Arguments> testIdTypeAnnotation() {
         return Stream.of(Arguments.of(EntityWithDefaults.class, String.class),
@@ -24,8 +21,9 @@ class EvaluateIdTypeAnnotationTest {
     @ParameterizedTest
     @MethodSource
     void testIdTypeAnnotation(Class<?> entityClass, Class<?> expectedIdClass) {
-        var entity = eventSourceEntityConfigurer.createConfigurer(entityClass);
-        assertEquals(expectedIdClass, entity.idType());
+        var entityDefinition = new EventSourcedEntityBeanBuildItem(entityClass);
+        assertEquals(entityClass, entityDefinition.itemClass());
+        assertEquals(expectedIdClass, entityDefinition.getIdClass());
     }
 
     @EventSourcedEntity

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>annotations</module>
     </modules>
 
 </project>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>test-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>at.meks.quarkiverse.axonframework-extension</groupId>
+            <artifactId>quarkus-axon-annotations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/AxonExtension.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/AxonExtension.java
@@ -49,7 +49,7 @@ public class AxonExtension {
     String profile;
 
     private org.axonframework.common.configuration.AxonConfiguration configuration;
-    private final Set<Class<?>> eventSourcedEntityClasses = new HashSet<>();
+    private final Set<EventSourcedEntityDefinition> eventSourcedEntityClasses = new HashSet<>();
     private final Set<Object> evenhandlers = new HashSet<>();
     private final Set<Object> commandhandlers = new HashSet<>();
     private final Set<Object> queryHandlers = new HashSet<>();
@@ -74,7 +74,7 @@ public class AxonExtension {
         }
     }
 
-    public void addEventSourcedEntityForRegistration(Class<?> eventSourcedEntityClass) {
+    public void addEventSourcedEntityForRegistration(EventSourcedEntityDefinition eventSourcedEntityClass) {
         eventSourcedEntityClasses.add(eventSourcedEntityClass);
     }
 

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/AxonInitializationRecorder.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/AxonInitializationRecorder.java
@@ -13,7 +13,7 @@ import io.smallrye.config.SmallRyeConfig;
 @Recorder
 public class AxonInitializationRecorder {
 
-    public void startAxon(BeanContainer beanContainer, Collection<Class<?>> eventSourcedEntityClasses,
+    public void startAxon(BeanContainer beanContainer, Collection<EventSourcedEntityDefinition> eventSourcedEntityClasses,
             Collection<Class<?>> commandhandlerClasses, Collection<Class<?>> queryhandlerClasses,
             Collection<Class<?>> eventhandlerClasses,
             Set<Class<?>> injectableBeanClasses) {

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/EventSourcedEntityDefinition.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/EventSourcedEntityDefinition.java
@@ -1,0 +1,4 @@
+package at.meks.quarkiverse.axon.runtime;
+
+public record EventSourcedEntityDefinition(Class<?> entityClass, Class<?> idClass) {
+}

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/AxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/AxonFrameworkConfigurer.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 
+import at.meks.quarkiverse.axon.runtime.EventSourcedEntityDefinition;
+
 /**
  * Interface for configuring Axon Framework components such as event sourced entities, handlers, and general configurations.
  */
@@ -21,7 +23,7 @@ public interface AxonFrameworkConfigurer {
      *
      * @param eventSourcedEntityClasses a set of aggregate class types to be registered.
      */
-    void eventSourcedEntityClasses(Set<Class<?>> eventSourcedEntityClasses);
+    void eventSourcedEntityClasses(Set<EventSourcedEntityDefinition> eventSourcedEntityClasses);
 
     /**
      * Registers event handler instances with the Axon Framework configuration.

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventSourcedEntityConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventSourcedEntityConfigurer.java
@@ -15,5 +15,5 @@ public interface EventSourcedEntityConfigurer {
      * @param eventSourcedEntity the class of the eventSourcedEntity type
      * @return an {@link EventSourcedEntityModule} instance for the given eventSourcedEntity type
      */
-    <ID, T> EventSourcedEntityModule<ID, T> createConfigurer(Class<T> eventSourcedEntity);
+    <T> EventSourcedEntityModule<?, T> createConfigurer(Class<T> eventSourcedEntity);
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventSourcedEntityConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/customizations/EventSourcedEntityConfigurer.java
@@ -13,7 +13,8 @@ public interface EventSourcedEntityConfigurer {
      *
      * @param <T> the type of the eventSourcedEntity
      * @param eventSourcedEntity the class of the eventSourcedEntity type
+     * @param idClass the class of the entity id
      * @return an {@link EventSourcedEntityModule} instance for the given eventSourcedEntity type
      */
-    <T> EventSourcedEntityModule<?, T> createConfigurer(Class<T> eventSourcedEntity);
+    <T> EventSourcedEntityModule<?, T> createConfigurer(Class<T> eventSourcedEntity, Class<?> idClass);
 }

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/AxonComponentenSetup.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/AxonComponentenSetup.java
@@ -8,6 +8,7 @@ import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
 import org.axonframework.messaging.queryhandling.configuration.QueryHandlingModule;
 
+import at.meks.quarkiverse.axon.runtime.EventSourcedEntityDefinition;
 import at.meks.quarkiverse.axon.runtime.customizations.EventSourcedEntityConfigurer;
 
 public class AxonComponentenSetup {
@@ -15,10 +16,11 @@ public class AxonComponentenSetup {
     @Inject
     EventSourcedEntityConfigurer entityConfigurer;
 
-    void configureEventSourcedEntities(EventSourcingConfigurer configurer, Set<Class<?>> eventSourcedEntityClasses) {
-        eventSourcedEntityClasses.forEach(
-                entity -> configurer.modelling(
-                        mc -> mc.registerEntity(entityConfigurer.createConfigurer(entity))));
+    void configureEventSourcedEntities(EventSourcingConfigurer configurer,
+            Set<EventSourcedEntityDefinition> eventSourcedEntityDefinition) {
+        eventSourcedEntityDefinition.forEach(
+                esed -> configurer.modelling(
+                        mc -> mc.registerEntity(entityConfigurer.createConfigurer(esed.entityClass(), esed.idClass()))));
     }
 
     void configureCommandHandlers(EventSourcingConfigurer configurer, Set<Object> commandhandlers) {

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import at.meks.quarkiverse.axon.runtime.EventSourcedEntityDefinition;
 import at.meks.quarkiverse.axon.runtime.conf.AxonConfiguration;
 import at.meks.quarkiverse.axon.runtime.conf.SubscribingProcessorConf;
 import at.meks.quarkiverse.axon.runtime.customizations.*;
@@ -76,7 +77,7 @@ public class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
     @Inject
     AxonComponentenSetup axonComponentSetup;
 
-    private Set<Class<?>> eventSourcedEntityClasses;
+    private Set<EventSourcedEntityDefinition> eventSourcedEntityDefinitions;
     private Set<Object> eventhandlers;
     private Set<Object> commandhandlers;
     private Set<Object> queryhandlers;
@@ -99,7 +100,7 @@ public class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
                 });
         configureTracing(configurer);
         eventstoreConfigurer.configure(configurer);
-        axonComponentSetup.configureEventSourcedEntities(configurer, eventSourcedEntityClasses);
+        axonComponentSetup.configureEventSourcedEntities(configurer, eventSourcedEntityDefinitions);
         configureMessageHandler(configurer);
         configureTransactionManagement(configurer);
         metricsConfigurer.configure(configurer);
@@ -212,8 +213,8 @@ public class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
     }
 
     @Override
-    public void eventSourcedEntityClasses(Set<Class<?>> eventSourcedEntityClasses) {
-        this.eventSourcedEntityClasses = eventSourcedEntityClasses;
+    public void eventSourcedEntityClasses(Set<EventSourcedEntityDefinition> eventSourcedEntityDefinitions) {
+        this.eventSourcedEntityDefinitions = eventSourcedEntityDefinitions;
     }
 
     @Override

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultEventSourceEntityConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultEventSourceEntityConfigurer.java
@@ -1,12 +1,9 @@
 package at.meks.quarkiverse.axon.runtime.defaults;
 
-import java.util.Arrays;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
 
-import at.meks.quarkiverse.axon.annotations.IdType;
 import at.meks.quarkiverse.axon.runtime.customizations.EventSourcedEntityConfigurer;
 import io.quarkus.arc.DefaultBean;
 
@@ -15,12 +12,7 @@ import io.quarkus.arc.DefaultBean;
 public class DefaultEventSourceEntityConfigurer implements EventSourcedEntityConfigurer {
 
     @Override
-    public <T> EventSourcedEntityModule<?, T> createConfigurer(Class<T> eventSourcedEntity) {
-        var idTypeAnnotation = Arrays.stream(eventSourcedEntity.getAnnotationsByType(IdType.class)).findFirst();
-        Class<?> idClass = String.class;
-        if (idTypeAnnotation.isPresent()) {
-            idClass = idTypeAnnotation.get().value();
-        }
+    public <T> EventSourcedEntityModule<?, T> createConfigurer(Class<T> eventSourcedEntity, Class<?> idClass) {
         return EventSourcedEntityModule.autodetected(idClass, eventSourcedEntity);
     }
 

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultEventSourceEntityConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultEventSourceEntityConfigurer.java
@@ -1,9 +1,12 @@
 package at.meks.quarkiverse.axon.runtime.defaults;
 
+import java.util.Arrays;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
 
+import at.meks.quarkiverse.axon.annotations.IdType;
 import at.meks.quarkiverse.axon.runtime.customizations.EventSourcedEntityConfigurer;
 import io.quarkus.arc.DefaultBean;
 
@@ -12,9 +15,13 @@ import io.quarkus.arc.DefaultBean;
 public class DefaultEventSourceEntityConfigurer implements EventSourcedEntityConfigurer {
 
     @Override
-    public <ID, T> EventSourcedEntityModule<ID, T> createConfigurer(Class<T> eventSourcedEntity) {
-        // TODO: Fix this by supporting entities with other id types than string
-        return EventSourcedEntityModule.autodetected((Class<ID>) String.class, eventSourcedEntity);
+    public <T> EventSourcedEntityModule<?, T> createConfigurer(Class<T> eventSourcedEntity) {
+        var idTypeAnnotation = Arrays.stream(eventSourcedEntity.getAnnotationsByType(IdType.class)).findFirst();
+        Class<?> idClass = String.class;
+        if (idTypeAnnotation.isPresent()) {
+            idClass = idTypeAnnotation.get().value();
+        }
+        return EventSourcedEntityModule.autodetected(idClass, eventSourcedEntity);
     }
 
 }

--- a/shared/test/model/pom.xml
+++ b/shared/test/model/pom.xml
@@ -42,6 +42,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>at.meks.quarkiverse.axonframework-extension</groupId>
+            <artifactId>quarkus-axon-annotations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/shared/test/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
+++ b/shared/test/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
@@ -32,7 +32,7 @@ import at.meks.quarkiverse.axon.shared.projection2.AnotherProjection;
 import io.quarkus.logging.Log;
 import io.quarkus.test.QuarkusExtensionTest;
 
-public class JavaArchiveTest {
+public abstract class JavaArchiveTest {
 
     protected static QuarkusExtensionTest application(JavaArchive javaArchive) {
         return new QuarkusExtensionTest()


### PR DESCRIPTION
The Spring extension from Axon Framework includes an `@EventSourced` annotation that composes `@EventSourcedEntity` + additional attributes. One of them is `idType`.

Without Spring there is no out-of-the-box way to annotate this information and the Quarkus extension cannot determine the type of the id. As jakarta does not have an equivalent to `@AliasFor` for composing annotations, we define a separate annotation specifically for the id type.