### PR TITLE
fixed a flaky test, because the assertions happened, before the projection was ready

### DIFF
--- a/shared/test/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
+++ b/shared/test/unittest/src/main/java/at/meks/quarkiverse/axon/shared/unittest/JavaArchiveTest.java
@@ -103,12 +103,16 @@ public abstract class JavaArchiveTest {
                     .untilAsserted(() -> assertTrue(
                             giftcardInMemoryHistory.wasEventHandled(new Api.CardRedeemedEvent(cardId, 1))));
 
-            CompletableFuture<GiftcardView> queryResult = queryGateway.query(new Api.GiftcardQuery(cardId),
-                    GiftcardView.class);
-            assertThat(queryResult)
-                    .succeedsWithin(Duration.ofSeconds(1))
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GiftcardView(cardId, 9, "Bruce Wayne"));
+            await().atMost(Duration.ofSeconds(10))
+                    .pollDelay(Duration.ZERO)
+                    .untilAsserted(() -> {
+                        CompletableFuture<GiftcardView> queryResult = queryGateway.query(new Api.GiftcardQuery(cardId),
+                                GiftcardView.class);
+                        assertThat(queryResult)
+                                .succeedsWithin(Duration.ofSeconds(1))
+                                .usingRecursiveComparison()
+                                .isEqualTo(new GiftcardView(cardId, 9, "Bruce Wayne"));
+                    });
 
             assertThatAllEventHandlerClassesWereInformed();
 


### PR DESCRIPTION
An assertion failed sometimes, because the projection wasn't ready at this point. It was fixed by retrying the assertion for 10 seconds, before it fails finally.