### PR TITLE
axon4: support for configuration of error handling in streaming eventprocessors

### DIFF
--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/AbstractOnErrorBlocksTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/AbstractOnErrorBlocksTest.java
@@ -1,0 +1,65 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.config.ProcessingGroup;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.SequenceNumber;
+import org.junit.jupiter.api.Test;
+
+import at.meks.quarkiverse.axon.shared.model.Api;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.logging.Log;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public abstract class AbstractOnErrorBlocksTest {
+
+    protected static QuarkusExtensionTest application() {
+        return new QuarkusExtensionTest()
+                .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                        .addClass(FailingBlockedProjection.class));
+    }
+
+    @Inject
+    CommandGateway commandGateway;
+
+    @Test
+    void testErrorBlock() {
+        var cardId = UUID.randomUUID().toString();
+        commandGateway.sendAndWait(new Api.IssueCardCommand(cardId, 10));
+        Awaitility.await().atMost(Duration.ofSeconds(20))
+                .untilAsserted(() -> assertSoftly(softly -> {
+                    softly.assertThat(FailingBlockedProjection.eventWasDelivered).isTrue();
+                    // because processor isCaught up doesn't return true, even if it retries an event and doesn't finish, it
+                    //  is asserted if the invocation for the one event happend more than once, or in this case at least 3 times.
+                    softly.assertThat(FailingBlockedProjection.invocationCount.get()).isGreaterThan(2);
+                }));
+    }
+
+    @ApplicationScoped
+    @ProcessingGroup("errorBlocks")
+    public static class FailingBlockedProjection {
+
+        private static final AtomicBoolean eventWasDelivered = new AtomicBoolean(false);
+        private static final AtomicInteger invocationCount = new AtomicInteger(0);
+
+        @EventHandler
+        void handle(Api.CardIssuedEvent event, @SequenceNumber long sequenceNumber) {
+            Log.infof("handling event sequence %s and throw an error", sequenceNumber);
+            eventWasDelivered.set(true);
+            int invocations = invocationCount.incrementAndGet();
+            Log.infof("invocationCount: %s", invocations);
+            throw new IllegalStateException("event handler failed for test purposes");
+        }
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/AbstractOnErrorContinuesTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/AbstractOnErrorContinuesTest.java
@@ -1,0 +1,73 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.config.ProcessingGroup;
+import org.axonframework.eventhandling.EventHandler;
+import org.junit.jupiter.api.Test;
+
+import at.meks.quarkiverse.axon.shared.model.Api;
+import at.meks.quarkiverse.axon.shared.unittest.JavaArchiveTest;
+import io.quarkus.logging.Log;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public abstract class AbstractOnErrorContinuesTest {
+
+    protected static QuarkusExtensionTest application() {
+        return new QuarkusExtensionTest()
+                .setArchiveProducer(() -> JavaArchiveTest.javaArchiveBase()
+                        .addClass(TestProjection.class));
+    }
+
+    @Inject
+    CommandGateway commandGateway;
+
+    @Test
+    void testErrorBlock() {
+        var cardId = UUID.randomUUID().toString();
+        commandGateway.sendAndWait(new Api.IssueCardCommand(cardId, 10));
+        Instant timestampAfterCommandProcessed = Instant.now();
+        Awaitility.await()
+                .pollDelay(Duration.ofSeconds(8))
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertSoftly(softly -> {
+                    softly.assertThat(TestProjection.eventWasDelivered).isTrue();
+                    softly.assertThat(TestProjection.invocationCount.get()).isEqualTo(1);
+                    // because processor isCaught up doesn't return true, even if it retries an event and doesn't finish,
+                    // the timestamp of the last invocation is asserted
+                    softly.assertThat(TestProjection.lastInvocationTime.get())
+                            .isBeforeOrEqualTo(timestampAfterCommandProcessed.plusSeconds(3));
+                }));
+    }
+
+    @ApplicationScoped
+    @ProcessingGroup("errorNotBlocking")
+    public static class TestProjection {
+
+        private static final AtomicBoolean eventWasDelivered = new AtomicBoolean(false);
+        private static final AtomicInteger invocationCount = new AtomicInteger(0);
+        private static final AtomicReference<Instant> lastInvocationTime = new AtomicReference<>();
+
+        @EventHandler
+        void handle(Api.CardIssuedEvent event) {
+            Log.info("handling event and throw an error");
+            eventWasDelivered.set(true);
+            int invocations = invocationCount.incrementAndGet();
+            lastInvocationTime.set(Instant.now());
+            Log.infof("invocationCount: %s", invocations);
+            throw new IllegalStateException("event handler failed for test purposes");
+        }
+    }
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/OnErrorBlocksTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/OnErrorBlocksTest.java
@@ -1,0 +1,14 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors.pooled;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.deployment.eventprocessors.AbstractOnErrorBlocksTest;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class OnErrorBlocksTest extends AbstractOnErrorBlocksTest {
+
+    @RegisterExtension
+    static QuarkusExtensionTest quarkusExtensionTest = application()
+            .withConfigurationResource("eventprocessors/pooled/defaults.properties");
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/OnErrorContinuesTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/pooled/OnErrorContinuesTest.java
@@ -1,0 +1,14 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors.pooled;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.deployment.eventprocessors.AbstractOnErrorContinuesTest;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class OnErrorContinuesTest extends AbstractOnErrorContinuesTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest quarkusExtensionTest = application()
+            .withConfigurationResource("eventprocessors/pooled/errorNotBlocking.properties");
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/tracking/OnErrorBlocksTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/tracking/OnErrorBlocksTest.java
@@ -1,0 +1,14 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors.tracking;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.deployment.eventprocessors.AbstractOnErrorBlocksTest;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class OnErrorBlocksTest extends AbstractOnErrorBlocksTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest quarkusExtensionTest = application()
+            .withConfigurationResource("eventprocessors/tracking/defaults.properties");
+
+}

--- a/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/tracking/OnErrorContinuesTest.java
+++ b/core/deployment/src/test/java/at/meks/quarkiverse/axon/deployment/eventprocessors/tracking/OnErrorContinuesTest.java
@@ -1,0 +1,14 @@
+package at.meks.quarkiverse.axon.deployment.eventprocessors.tracking;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import at.meks.quarkiverse.axon.deployment.eventprocessors.AbstractOnErrorContinuesTest;
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class OnErrorContinuesTest extends AbstractOnErrorContinuesTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest quarkusExtensionTest = application()
+            .withConfigurationResource("eventprocessors/tracking/errorNotBlocking.properties");
+
+}

--- a/core/deployment/src/test/resources/eventprocessors/pooled/errorNotBlocking.properties
+++ b/core/deployment/src/test/resources/eventprocessors/pooled/errorNotBlocking.properties
@@ -1,0 +1,2 @@
+quarkus.axon.event-processing.default-event-processing-type=pooled
+quarkus.axon.exception-handling.eventprocessors.streaming.retry=false

--- a/core/deployment/src/test/resources/eventprocessors/tracking/errorNotBlocking.properties
+++ b/core/deployment/src/test/resources/eventprocessors/tracking/errorNotBlocking.properties
@@ -1,0 +1,2 @@
+quarkus.axon.event-processing.default-event-processing-type=tracking
+quarkus.axon.exception-handling.eventprocessors.streaming.retry=false

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/conf/AxonConfiguration.java
@@ -139,6 +139,34 @@ public interface AxonConfiguration {
          */
         @WithDefault("true")
         boolean wrapOnQueryHandler();
+
+        /**
+         * exception handling for event processors.
+         */
+        EventProcessorsErrorHandling eventprocessors();
+
+    }
+
+    interface EventProcessorsErrorHandling {
+
+        /**
+         * exception handling for streaming event processors.
+         */
+        StreamingEventProcessorErrorHandling streaming();
+    }
+
+    interface StreamingEventProcessorErrorHandling {
+
+        /**
+         * if set to true, the streaming event processors retry processing an event in case of an exception.
+         * That means that the processor will not be able to catch up to the head of the events, as long as processing an event
+         * fails.
+         * If set to false, the axon framework default behavior is used.
+         */
+        @WithDefault("true")
+        @WithName("retry") // if set to a more complex name like retry-on-error the build fails SRCFG00027: Could not find a mapping for at.meks.quarkiverse.axon.runtime.health.AxonBuildTimeConfiguration
+        boolean retryOnError();
+
     }
 
     interface CommandRetryScheduling {

--- a/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
+++ b/core/runtime/src/main/java/at/meks/quarkiverse/axon/runtime/defaults/DefaultAxonFrameworkConfigurer.java
@@ -17,6 +17,7 @@ import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.DefaultConfigurer;
 import org.axonframework.config.EventProcessingConfigurer;
+import org.axonframework.eventhandling.PropagatingErrorHandler;
 import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,6 +115,7 @@ public class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
 
     private void configureEventHandling(Configurer configurer) {
         setDefaultEventProcessorType(configurer);
+        setEventProcessorErrorHandling(configurer.eventProcessing());
         EventProcessingConfigurer processingConfigurer = configurer.eventProcessing();
         assignProcessingGroupsToSubscribingEventProcessor(processingConfigurer);
         if (!eventhandlers.isEmpty() || !sagaEventhandlerClasses.isEmpty()) {
@@ -133,6 +135,13 @@ public class DefaultAxonFrameworkConfigurer implements AxonFrameworkConfigurer {
                 case POOLED -> eventProcessingConfigurer.usingPooledStreamingEventProcessors();
             }
         });
+    }
+
+    private void setEventProcessorErrorHandling(EventProcessingConfigurer eventProcessingConfigurer) {
+        if (axonConfiguration.exceptionHandling().eventprocessors().streaming().retryOnError()) {
+            eventProcessingConfigurer
+                    .registerDefaultListenerInvocationErrorHandler(conf -> PropagatingErrorHandler.instance());
+        }
     }
 
     private void assignProcessingGroupsToSubscribingEventProcessor(EventProcessingConfigurer configurer) {

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server.adoc
@@ -58,7 +58,7 @@ endif::add-copy-button-to-config-props[]
 [.description]
 --
 A comma separated list of Axon Server servers. Each element is hostname or hostname:grpcPort. When no grpcPort is specified, the port of `QuarkusAxonServerConfiguration++#++defaultGrpcPort()` is used. The following examples are valid configurations:
- -
+
 axon-server-name
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon-server_quarkus.axon.adoc
@@ -58,7 +58,7 @@ endif::add-copy-button-to-config-props[]
 [.description]
 --
 A comma separated list of Axon Server servers. Each element is hostname or hostname:grpcPort. When no grpcPort is specified, the port of `QuarkusAxonServerConfiguration++#++defaultGrpcPort()` is used. The following examples are valid configurations:
- -
+
 axon-server-name
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon.adoc
@@ -353,6 +353,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a| [[quarkus-axon_quarkus-axon-exception-handling-eventprocessors-streaming-retry]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-eventprocessors-streaming-retry[`+++quarkus.axon.exception-handling.eventprocessors.streaming.retry+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.exception-handling.eventprocessors.streaming.retry+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+if set to true, the streaming event processors retry processing an event in case of an exception. That means that the processor will not be able to catch up to the head of the events, as long as processing an event fails. If set to false, the axon framework default behavior is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_EXCEPTION_HANDLING_EVENTPROCESSORS_STREAMING_RETRY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_EXCEPTION_HANDLING_EVENTPROCESSORS_STREAMING_RETRY+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval[`+++quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-axon_quarkus.axon.adoc
@@ -353,6 +353,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a| [[quarkus-axon_quarkus-axon-exception-handling-eventprocessors-streaming-retry]] [.property-path]##link:#quarkus-axon_quarkus-axon-exception-handling-eventprocessors-streaming-retry[`+++quarkus.axon.exception-handling.eventprocessors.streaming.retry+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.axon.exception-handling.eventprocessors.streaming.retry+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+if set to true, the streaming event processors retry processing an event in case of an exception. That means that the processor will not be able to catch up to the head of the events, as long as processing an event fails. If set to false, the axon framework default behavior is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AXON_EXCEPTION_HANDLING_EVENTPROCESSORS_STREAMING_RETRY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AXON_EXCEPTION_HANDLING_EVENTPROCESSORS_STREAMING_RETRY+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval]] [.property-path]##link:#quarkus-axon_quarkus-axon-command-gateway-retry-scheduling-fixed-retry-interval[`+++quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.axon.command-gateway.retry.scheduling.fixed-retry-interval+++[]

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.37.0</quarkus.version>
+        <quarkus.version>3.38.1</quarkus.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION


By default event processing is retried if an exception occurs.
It can be configured to not retry and use the default behavior of the framework.